### PR TITLE
Improve preprocessor handling, add missing keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -247,7 +247,7 @@
   'keywords':
     'patterns': [
       {
-        'match': '\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield)\\b'
+        'match': '\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b'
         'name': 'keyword.control.source.cs'
       }
       {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -459,9 +459,6 @@
         'name': 'meta.preprocessor.source.cs'
       }
       {
-        'captures':
-          '2':
-            'name': 'keyword.control.import.source.cs'
         'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b'
         'name': 'meta.preprocessor.source.cs'
       }

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -448,7 +448,7 @@
         'captures':
           '2':
             'name': 'meta.toc-list.region.source.cs'
-        'match': '^\\s*#\\s*(region)\\b(.*)$'
+        'match': '^\\s*#\\s*(region)\\b\\s*([^\/]+)\\s'
         'name': 'meta.preprocessor.source.cs'
       }
       {
@@ -459,7 +459,7 @@
         'name': 'meta.preprocessor.source.cs'
       }
       {
-        'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b'
+        'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\/]+)\\s'
         'name': 'meta.preprocessor.source.cs'
       }
     ]

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -455,7 +455,7 @@
         'captures':
           '2':
             'name': 'entity.name.function.preprocessor.source.cs'
-        'match': '^\\s*#\\s*(define)\\b\\s*(\\S*)'
+        'match': '^\\s*#\\s*(define|undef|if|elif)\\b\\s*(\\S*)'
         'name': 'meta.preprocessor.source.cs'
       }
       {


### PR DESCRIPTION
This pull request achieves four things (one per commit):

* Highlights conditionals defined with #define across #if, #undef and #elif 
* Removes an unused capture from a preprocessor rule
* Handles // comments at the end of preprocessor lines (e.g. line 276 of https://github.com/dotnet/corefx/blob/master/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs#276)
* Adds the 'await' keyword that was missing