### PR TITLE
Proper use of Console.WriteLine snippet

### DIFF
--- a/snippets/language-csharp.cson
+++ b/snippets/language-csharp.cson
@@ -122,9 +122,6 @@
   'While':
     'prefix': 'wh'
     'body': 'while (${1:Condition}) {\n\t$0\n}'
-  'Write':
-    'prefix': 'w'
-    'body': 'Console.Write($1);$0'
   'WriteLine':
-    'prefix': 'wl'
+    'prefix': 'cw'
     'body': 'Console.WriteLine($1);$0'


### PR DESCRIPTION
Visual Studio, Xamarin Studio (Monodevelop) and SharpDevelop uses cw snippet for Console.WriteLine so I changed it here to follow common use.