### PR TITLE
Adds support for escaped keywords such as @event

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -262,6 +262,12 @@
         'match': '\\b(var|event|delegate|add|remove|set|get|value)\\b'
         'name': 'keyword.other.source.cs'
       }
+      {
+        'match': '[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof
+        |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending
+        |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b'
+        'name': 'meta.class.body.source.cs'
+      }
     ]
   'method':
     'patterns': [


### PR DESCRIPTION
This pull request sets keywords that have been escaped using @ to the standard source class, mimicking the default behavior of visual studio. 
The reason its done by setting keywords preceded by @ to meta.class.body.source.cs rather than simply ignoring, is that as far as i am aware this can't be done efficiency in regex without using a lookbehind.