### PR TITLE
Add Grammar support for Cake Build

### DIFF
--- a/grammars/cake.cson
+++ b/grammars/cake.cson
@@ -1,0 +1,14 @@
+'scopeName': 'source.cake'
+'name': 'C# Cake File'
+'fileTypes': [
+  'cake'
+]
+'patterns': [
+  {
+    'include': 'source.cs'
+  }
+  {
+    'match': '^#(load|l)'
+    'name': 'preprocessor.source.cake'
+  }
+]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -15,6 +15,12 @@ describe "Language C# package", ->
       expect(grammar).toBeDefined()
       expect(grammar.scopeName).toBe "source.csx"
 
+  describe "C# Cake grammar", ->
+    it "parses the grammar", ->
+      grammar = atom.grammars.grammarForScopeName("source.cake")
+      expect(grammar).toBeDefined()
+      expect(grammar.scopeName).toBe "source.cake"
+
   describe "NAnt Build File grammar", ->
     it "parses the grammar", ->
       grammar = atom.grammars.grammarForScopeName("source.nant-build")


### PR DESCRIPTION
Add grammar support for Cake Build. See cakebuild.net for more details.
Largely mirrors CSX support.