### PR TITLE
Correct scope for var keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -259,8 +259,12 @@
         'name': 'keyword.operator.source.cs'
       }
       {
-        'match': '\\b(var|event|delegate|fixed|add|remove|set|get|value)\\b'
+        'match': '\\b(event|delegate|fixed|add|remove|set|get|value)\\b'
         'name': 'keyword.other.source.cs'
+      }
+      {
+        'match': '\\b(var)\\b'
+        'name': 'storage.type.var.source.cs'
       }
       {
         'match': '[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof


### PR DESCRIPTION
As reported in #33, the current scope for `var` is incorrect. This PR changes it to `storage.type.source.cs`.