### PR TITLE
Properly escape tokens

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -10,7 +10,7 @@
     'captures':
       '1':
         'name': 'keyword.other.using.cs'
-    'begin': '^\\s*(using)\b\s*'
+    'begin': '^\\s*(using)\\b\\s*'
     'end': '\\s*(?:$|(;))'
     'name': 'meta.keyword.using.cs'
   }
@@ -458,7 +458,7 @@
         'captures':
           '2':
             'name': 'meta.toc-list.region.cs'
-        'match': '^\\s*#\\s*(region)\\b\\s*([^\/]+)\\s'
+        'match': '^\\s*#\\s*(region)\\b\\s*([^\\/]+)\\s'
         'name': 'meta.preprocessor.cs'
       }
       {
@@ -469,7 +469,7 @@
         'name': 'meta.preprocessor.cs'
       }
       {
-        'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\/]+)\\s'
+        'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\\/]+)\\s'
         'name': 'meta.preprocessor.cs'
       }
     ]


### PR DESCRIPTION
Some tokens weren't being double-escaped.