### PR TITLE
grammar fix #11: method signatures with generic parameters

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -90,13 +90,19 @@
         'include': '#comments'
       }
       {
-        'captures':
+        'begin': '(class|struct|interface|enum)\\s+(\\w+)(?=[<]?)'
+        'beginCaptures':
           '1':
             'name': 'storage.modifier.cs'
           '2':
             'name': 'entity.name.type.class.cs'
-        'match': '(class|struct|interface|enum)\\s+(\\w+)'
+        'end': '(?=[>:{])'
         'name': 'meta.class.identifier.cs'
+        'patterns': [
+          {
+            'include': '#genericParameters'
+          }
+        ]
       }
       {
         'begin': ':'
@@ -446,7 +452,7 @@
     'begin': '<(in|out)?\\s*\\b([\\w.\\[\\]]+)'
     'beginCaptures':
       '1':
-        'name': 'storage.type.generic.variance.cs'
+        'name': 'keyword.storage.type.generic.variance.cs'
       '2':
         'name': 'storage.type.generic.arg.cs'
     'end': '(?:(,)|(?=[>]))'

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -316,13 +316,29 @@
             'include': '#builtinTypes'
           }
           {
-            'begin': '([\\w.]+)\\s*\\('
+            'begin': '(?=\\w.*\\s+[\\w.]+\\s*\\()'
+            'end': '(?=[\\w.]+\\s*\\()'
+            'name': 'meta.method.return-type.cs'
+            'patterns': [
+              {
+                'include': '#builtinTypes'
+              }
+              {
+                'include': '#genericParameters'
+              }
+            ]
+          }
+          {
+            'begin': '([\\w.]+)\\s*(?=[\\(<])'
             'beginCaptures':
               '1':
                 'name': 'entity.name.function.cs'
             'end': '\\)'
             'name': 'meta.method.identifier.cs'
             'patterns': [
+              {
+                'include': '#genericParameters'
+              }
               {
                 'include': '#parameters'
               }
@@ -331,16 +347,7 @@
               }
             ]
           }
-          {
-            'begin': '(?=\\w.*\\s+[\\w.]+\\s*\\()'
-            'end': '(?=[\\w.]+\\s*\\()'
-            'name': 'meta.method.return-type.cs'
-            'patterns': [
-              {
-                'include': '#builtinTypes'
-              }
-            ]
-          }
+
           {
             'begin': ':\\s*(this|base)\\s*\\('
             'beginCaptures':
@@ -384,7 +391,7 @@
             'begin': '([\\w.]+)\\s*(?={)'
             'captures':
               '1':
-                'name': 'entity.name.function.cs'
+                'name': '.cs'
             'end': '(?={)'
             'name': 'meta.method.identifier.cs'
           }
@@ -435,6 +442,18 @@
         'include': '#code'
       }
     ]
+  'genericParameters':
+    'begin': '<(in|out)?\\s*\\b([\\w.\\[\\]]+)'
+    'beginCaptures':
+      '1':
+        'name': 'storage.type.generic.variance.cs'
+      '2':
+        'name': 'storage.type.generic.arg.cs'
+    'end': '(?:(,)|(?=[>]))'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.separator.parameter.cs'
+    'patterns': [ ]
   'parameters':
     'begin': '\\b(ref|params|out)?\\s*\\b([\\w.\\[\\]]+)\\s+(\\w+)\\s*(=)?'
     'beginCaptures':

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -449,7 +449,7 @@
       }
     ]
   'genericParameters':
-    'begin': '<(in|out)?\\s*\\b([\\w.\\[\\]]+)'
+    'begin': '\\b(in|out)?\\s*\\b([\\w.\\[\\]]+)'
     'beginCaptures':
       '1':
         'name': 'keyword.storage.type.generic.variance.cs'


### PR DESCRIPTION
### Before

Notice how method names with Generic parameters aren't parsed as `entity.name.function.cs`. You can tell because `Register<TEvent>` has no style applied.
Also, Generic parameters aren't recognized in method return-types.

<img width="705" alt="broken method signatures" src="https://cloud.githubusercontent.com/assets/97470/13099398/89615db0-d4e6-11e5-8326-e7c2994eef5e.png">
### After

Method names with Generic parameters are recognized as `entity.name.function.cs`, and the Generic params themselves are recognized.
Generic params in return-types are also recognized.

<img width="695" alt="fixed method signatures" src="https://cloud.githubusercontent.com/assets/97470/13099397/86f9c2f6-d4e6-11e5-9539-f71698b5f35a.png">
### Known issue
- Can't seem to figure out how to get generic params to be recognized after the first param. Tried to copy what `#parameters` pattern does, but doesn't seem to work here. Any help would be appreciated, but this is still an improvement even without this sub-fix.
