### PR TITLE
Make nameof a keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -255,7 +255,7 @@
         'name': 'keyword.linq.cs'
       }
       {
-        'match': '\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc)\\b'
+        'match': '\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|nameof)\\b'
         'name': 'keyword.operator.cs'
       }
       {
@@ -269,7 +269,8 @@
       {
         'match': '[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof
         |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending
-        |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b'
+        |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock
+        |yield|await|nameof)\\b'
         'name': 'meta.class.body.cs'
       }
     ]


### PR DESCRIPTION
The `nameof` keyword was recently introduced with C# 6, however [at the moment](https://github.com/dotnet/corefx/blob/1bd332f2e5f559c2eab276acb0d9e4256085ec2f/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs#L13) it doesn't seem to be getting highlighted properly in GitHub. This pull request adds `nameof` as a recognized keyword to the grammar so it'll get picked up.