### PR TITLE
Make C# 6's when a keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -247,7 +247,7 @@
   'keywords':
     'patterns': [
       {
-        'match': '\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await)\\b'
+        'match': '\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|when)\\b'
         'name': 'keyword.control.cs'
       }
       {
@@ -270,7 +270,7 @@
         'match': '[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof
         |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending
         |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock
-        |yield|await|nameof)\\b'
+        |yield|await|nameof|when)\\b'
         'name': 'meta.class.body.cs'
       }
     ]


### PR DESCRIPTION
In addition to `nameof`, C# 6 also introduced the `when` keyword to add exception filters to the language. This pull request follows up on #53 by making the latter a keyword, as well.