### PR TITLE
Add `dynamic` as a C# 4 keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -71,7 +71,7 @@
   'builtinTypes':
     'patterns': [
       {
-        'match': '\\b(bool|byte|sbyte|char|decimal|double|float|int|uint|long|ulong|object|short|ushort|string|void|class|struct|enum|interface)\\b'
+        'match': '\\b(bool|byte|sbyte|char|decimal|double|float|int|uint|long|ulong|object|short|ushort|string|void|class|struct|enum|interface|dynamic)\\b'
         'name': 'storage.type.cs'
       }
     ]


### PR DESCRIPTION
C# 4 added the keyword `dynamic`, which is a new type in addition to the other built-in ones like `string`, `object`, etc. This code should syntax highlight:

```cs
object thing = new object();
dynamic bar = thing;
```

For more info, see [this link](https://msdn.microsoft.com/en-us/library/dd264741.aspx) about the keyword on MSDN.

cc @50Wliu 