### PR TITLE
Improve preprocessor and add specs

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -476,20 +476,11 @@
     'patterns': [
       {
         'captures':
-          '2':
-            'name': 'meta.toc-list.region.cs'
-        'match': '^\\s*#\\s*(region)\\b\\s*([^\\/]+)\\s'
-        'name': 'meta.preprocessor.cs'
-      }
-      {
-        'captures':
-          '2':
+          '1':
+            'name': 'directive.preprocessor.cs'
+          '3':
             'name': 'entity.name.function.preprocessor.cs'
-        'match': '^\\s*#\\s*(define|undef|if|elif)\\b\\s*(\\S*)'
-        'name': 'meta.preprocessor.cs'
-      }
-      {
-        'match': '^\\s*#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion)\\b\\s*([^\\/]+)?\\s'
+        'match': '^\\s*(#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion))\\b\\s*(.*?)(?=$|\\/\\/)'
         'name': 'meta.preprocessor.cs'
       }
     ]


### PR DESCRIPTION
This does a few things;

1. Optimizes the preprocessor block to be a single matcher
2. Removes the unused toc-list for regions
3. Adds a new directive.preprocessor.cs that can be styled (e.g. the #if bit)
4. Adds comprehensive test coverage for all preprocessor instructions with leading whitespace and trailing line comments in a variety of contexts