### PR TITLE
Allow comments in more places

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -303,6 +303,9 @@
           {
             'include': '#builtinTypes'
           }
+          {
+            'include': '#comments'
+          }
         ]
       }
       {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -375,6 +375,9 @@
             ]
           }
           {
+            'include': '#comments'
+          }
+          {
             'begin': '{'
             'beginCaptures':
               '0':


### PR DESCRIPTION
Allows you to have comments;

- Inside an attribute declaration

```csharp
[Attribute(1) /* Here */]
```

- After a method parameter list before the code body, e.g.

```csharp
void A() /* Here */ 
{
```