### PR TITLE
Reformat grammars into default cson format

### DIFF
--- a/grammars/build.cson
+++ b/grammars/build.cson
@@ -1,68 +1,68 @@
-'scopeName': 'source.nant-build'
-'name': 'NAnt Build File'
-'fileTypes': [
-  'build'
+scopeName: "source.nant-build"
+name: "NAnt Build File"
+fileTypes: [
+  "build"
 ]
-'foldingStartMarker': '<[^!?/>]+|<!--'
-'foldingStopMarker': '/>|</[^?>]+|-->'
-'patterns': [
+foldingStartMarker: "<[^!?/>]+|<!--"
+foldingStopMarker: "/>|</[^?>]+|-->"
+patterns: [
   {
-    'begin': '<!--'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.nant'
-    'end': '-->'
-    'name': 'comment.block.nant'
+    begin: "<!--"
+    captures:
+      "0":
+        name: "punctuation.definition.comment.nant"
+    end: "-->"
+    name: "comment.block.nant"
   }
   {
-    'begin': '(</?)([-_a-zA-Z0-9:]+)'
-    'captures':
-      '1':
-        'name': 'punctuation.definition.tag.nant'
-      '2':
-        'name': 'entity.name.tag.nant'
-    'end': '(/?>)'
-    'name': 'meta.tag.nant'
-    'patterns': [
+    begin: "(</?)([-_a-zA-Z0-9:]+)"
+    captures:
+      "1":
+        name: "punctuation.definition.tag.nant"
+      "2":
+        name: "entity.name.tag.nant"
+    end: "(/?>)"
+    name: "meta.tag.nant"
+    patterns: [
       {
-        'match': ' ([a-zA-Z-]+)'
-        'name': 'entity.other.attribute-name.nant'
+        match: " ([a-zA-Z-]+)"
+        name: "entity.other.attribute-name.nant"
       }
       {
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.nant'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.nant'
-        'name': 'string.quoted.double.nant'
+        begin: "\""
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.nant"
+        end: "\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.nant"
+        name: "string.quoted.double.nant"
       }
       {
-        'begin': '\''
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.nant'
-        'end': '\''
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.nant'
-        'name': 'string.quoted.single.nant'
+        begin: "'"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.nant"
+        end: "'"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.nant"
+        name: "string.quoted.single.nant"
       }
     ]
   }
   {
-    'captures':
-      '1':
-        'name': 'punctuation.definition.constant.nant'
-      '3':
-        'name': 'punctuation.definition.constant.nant'
-    'match': '(&)([a-zA-Z]+|#[0-9]+|#x[0-9a-fA-F]+)(;)'
-    'name': 'constant.character.entity.nant'
+    captures:
+      "1":
+        name: "punctuation.definition.constant.nant"
+      "3":
+        name: "punctuation.definition.constant.nant"
+    match: "(&)([a-zA-Z]+|#[0-9]+|#x[0-9a-fA-F]+)(;)"
+    name: "constant.character.entity.nant"
   }
   {
-    'match': '&'
-    'name': 'invalid.illegal.bad-ampersand.nant'
+    match: "&"
+    name: "invalid.illegal.bad-ampersand.nant"
   }
 ]

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -1,518 +1,515 @@
-'scopeName': 'source.cs'
-'name': 'C#'
-'fileTypes': [
-  'cs'
+scopeName: "source.cs"
+name: "C#"
+fileTypes: [
+  "cs"
 ]
-'foldingStartMarker': '^\\s*#\\s*region|^\\s*/\\*|^(?![^{]*?//|[^{]*?/\\*(?!.*?\\*/.*?\\{)).*?\\{\\s*($|//|/\\*(?!.*?\\*/.*\\S))'
-'foldingStopMarker': '^\\s*#\\s*endregion|^\\s*\\*/|^\\s*\\}'
-'patterns': [
+foldingStartMarker: "^\\s*#\\s*region|^\\s*/\\*|^(?![^{]*?//|[^{]*?/\\*(?!.*?\\*/.*?\\{)).*?\\{\\s*($|//|/\\*(?!.*?\\*/.*\\S))"
+foldingStopMarker: "^\\s*#\\s*endregion|^\\s*\\*/|^\\s*\\}"
+patterns: [
   {
-    'include': '#using'
+    include: "#using"
   }
   {
-    'include': '#namespace'
+    include: "#namespace"
   }
   {
-    'include': '#code'
+    include: "#code"
   }
 ]
-'repository':
-  'using':
-    'begin': '^\\s*(using)\\b\\s+(static)?\\b\\s*([\\w.]+)'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.other.using.cs'
-      '2':
-        'name': 'keyword.other.using.cs'
-      '3':
-        'name': 'entity.name.type.namespace.cs'
-    'end': '\\s*(?:$|(;))'
-  'namespace':
-    'begin': '^\\s*((namespace)\\s+([\\w.]+))'
-    'beginCaptures':
-      '1':
-        'name': 'meta.namespace.identifier.cs'
-      '2':
-        'name': 'keyword.other.namespace.cs'
-      '3':
-        'name': 'entity.name.type.namespace.cs'
-    'end': '}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.section.namespace.end.cs'
-    'name': 'meta.namespace.cs'
-    'patterns': [
+repository:
+  using:
+    begin: "^\\s*(using)\\b\\s+(static)?\\b\\s*([\\w.]+)"
+    beginCaptures:
+      "1":
+        name: "keyword.other.using.cs"
+      "2":
+        name: "keyword.other.using.cs"
+      "3":
+        name: "entity.name.type.namespace.cs"
+    end: "\\s*(?:$|(;))"
+  namespace:
+    begin: "^\\s*((namespace)\\s+([\\w.]+))"
+    beginCaptures:
+      "1":
+        name: "meta.namespace.identifier.cs"
+      "2":
+        name: "keyword.other.namespace.cs"
+      "3":
+        name: "entity.name.type.namespace.cs"
+    end: "}"
+    endCaptures:
+      "0":
+        name: "punctuation.section.namespace.end.cs"
+    name: "meta.namespace.cs"
+    patterns: [
       {
-        'begin': '{'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.namespace.begin.cs'
-        'end': '(?=})'
-        'name': 'meta.namespace.body.cs'
-        'patterns': [
+        begin: "{"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.namespace.begin.cs"
+        end: "(?=})"
+        name: "meta.namespace.body.cs"
+        patterns: [
           {
-            'include': '#using'
+            include: "#using"
           }
           {
-            'include': '#namespace'
+            include: "#namespace"
           }
           {
-            'include': '#code'
-          }
-        ]
-      }
-    ]
-  'block':
-    'patterns': [
-      {
-        'begin': '{'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.block.begin.cs'
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.block.end.cs'
-        'name': 'meta.block.cs'
-        'patterns': [
-          {
-            'include': '#code'
+            include: "#code"
           }
         ]
       }
     ]
-  'builtinTypes':
-    'patterns': [
+  block:
+    patterns: [
       {
-        'match': '\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort|)\\s*(\\?|\\*|\\[\\s*\\])?\\s'
-        'name': 'storage.value.type.cs'
-        'captures':
-          '2':
-            'name': 'punctuation.storage.type.modifier.cs'
-      }
-      {
-        'match': '\\b(dynamic|object|string)\\s*(\\*|\\[\\s*\\])?\\s'
-        'name': 'storage.reference.type.cs'
-        'captures':
-          '2':
-            'name': 'punctuation.storage.type.modifier.cs'
-      }
-      {
-        'match': '\\b(void|class|struct|interface)\\s'
-        'name': 'storage.type.cs'
-      }
-    ]
-  'class':
-    'begin': '(?=\\w?[\\w\\s]*(?:class|struct|interface|enum)\\s+\\w+)'
-    'end': '}'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.section.class.end.cs'
-    'name': 'meta.class.cs'
-    'patterns': [
-      {
-        'include': '#storage-modifiers'
-      }
-      {
-        'include': '#comments'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'storage.modifier.cs'
-          '2':
-            'name': 'entity.name.type.class.cs'
-        'match': '(class|struct|interface|enum)\\s+(\\w+)'
-        'name': 'meta.class.identifier.cs'
-      }
-      {
-        'begin': ':'
-        'end': '(?={)'
-        'patterns': [
+        begin: "{"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.block.begin.cs"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.block.end.cs"
+        name: "meta.block.cs"
+        patterns: [
           {
-            'captures':
-              '1':
-                'name': 'storage.type.cs'
-            'match': '\\s*,?([A-Za-z_]\\w*)\\b'
-          }
-        ]
-      }
-      {
-        'begin': '{'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.class.begin.cs'
-        'end': '(?=})'
-        'name': 'meta.class.body.cs'
-        'patterns': [
-          {
-            'include': '#method'
-          }
-          {
-            'include': '#code'
+            include: "#code"
           }
         ]
       }
     ]
-  'code':
-    'patterns': [
+  builtinTypes:
+    patterns: [
       {
-        'include': '#block'
+        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort|)\\s*(\\?|\\*|\\[\\s*\\])?\\s"
+        name: "storage.value.type.cs"
+        captures:
+          "2":
+            name: "punctuation.storage.type.modifier.cs"
       }
       {
-        'include': '#comments'
+        match: "\\b(dynamic|object|string)\\s*(\\*|\\[\\s*\\])?\\s"
+        name: "storage.reference.type.cs"
+        captures:
+          "2":
+            name: "punctuation.storage.type.modifier.cs"
       }
       {
-        'include': '#class'
-      }
-      {
-        'include': '#constants'
-      }
-      {
-        'include': '#storage-modifiers'
-      }
-      {
-        'include': '#keywords'
-      }
-      {
-        'include': '#preprocessor'
-      }
-      {
-        'include': '#method-call'
-      }
-      {
-        'include': '#builtinTypes'
-      }
-      {
-        'include': '#documentation'
+        match: "\\b(void|class|struct|interface)\\s"
+        name: "storage.type.cs"
       }
     ]
-  'comments':
-    'patterns': [
+  class:
+    begin: "(?=\\w?[\\w\\s]*(?:class|struct|interface|enum)\\s+\\w+)"
+    end: "}"
+    endCaptures:
+      "0":
+        name: "punctuation.section.class.end.cs"
+    name: "meta.class.cs"
+    patterns: [
       {
-        'begin': '///'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.cs'
-        'end': '$\\n?'
-        'name': 'comment.block.documentation.cs'
-        'patterns': [
+        include: "#storage-modifiers"
+      }
+      {
+        include: "#comments"
+      }
+      {
+        captures:
+          "1":
+            name: "storage.modifier.cs"
+          "2":
+            name: "entity.name.type.class.cs"
+        match: "(class|struct|interface|enum)\\s+(\\w+)"
+        name: "meta.class.identifier.cs"
+      }
+      {
+        begin: ":"
+        end: "(?={)"
+        patterns: [
           {
-            'include': 'text.xml'
+            captures:
+              "1":
+                name: "storage.type.cs"
+            match: "\\s*,?([A-Za-z_]\\w*)\\b"
           }
         ]
       }
       {
-        'begin': '/\\*'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.cs'
-        'end': '\\*/\\n?'
-        'name': 'comment.block.cs'
-      }
-      {
-        'begin': '//'
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.cs'
-        'end': '$\\n?'
-        'name': 'comment.line.double-slash.cs'
-      }
-    ]
-  'constants':
-    'patterns': [
-      {
-        'match': '\\b(true|false|null|this|base)\\b'
-        'name': 'constant.language.cs'
-      }
-      {
-        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
-        'name': 'constant.numeric.cs'
-      }
-      {
-        'captures':
-          '0':
-            'name': 'punctuation.definition.string.begin.cs'
-        'match': '@"([^"]|"")*"'
-        'name': 'string.quoted.double.literal.cs'
-      }
-      {
-        'begin': '"'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.cs'
-        'end': '"'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.cs'
-        'name': 'string.quoted.double.cs'
-        'patterns': [
+        begin: "{"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.class.begin.cs"
+        end: "(?=})"
+        name: "meta.class.body.cs"
+        patterns: [
           {
-            'match': '\\\\.'
-            'name': 'constant.character.escape.cs'
+            include: "#method"
           }
-        ]
-      }
-      {
-        'begin': '\''
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.string.begin.cs'
-        'end': '\''
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.string.end.cs'
-        'name': 'string.quoted.single.cs'
-        'patterns': [
           {
-            'match': '\\\\.'
-            'name': 'constant.character.escape.cs'
+            include: "#code"
           }
         ]
       }
     ]
-  'keywords':
-    'patterns': [
+  code:
+    patterns: [
       {
-        'match': '\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|when)\\b'
-        'name': 'keyword.control.cs'
+        include: "#block"
       }
       {
-        'match': '\\b(from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending)\\b'
-        'name': 'keyword.linq.cs'
+        include: "#comments"
       }
       {
-        'match': '\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|nameof)\\b'
-        'name': 'keyword.operator.cs'
+        include: "#class"
       }
       {
-        'match': '\\b(event|delegate|fixed|add|remove|set|get|value|alias|global)\\b'
-        'name': 'keyword.other.cs'
+        include: "#constants"
       }
       {
-        'match': '\\b(var)\\b'
-        'name': 'storage.type.var.cs'
+        include: "#storage-modifiers"
       }
       {
-        'match': '[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof
-        |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending
-        |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock
-        |yield|await|nameof|when|alias|global)\\b'
-        'name': 'meta.class.body.cs'
+        include: "#keywords"
+      }
+      {
+        include: "#preprocessor"
+      }
+      {
+        include: "#method-call"
+      }
+      {
+        include: "#builtinTypes"
+      }
+      {
+        include: "#documentation"
       }
     ]
-  'method':
-    'patterns': [
+  comments:
+    patterns: [
       {
-        'begin': '\\['
-        'end': '\\]'
-        'name': 'meta.method.annotation.cs'
-        'patterns': [
+        begin: "///"
+        captures:
+          "0":
+            name: "punctuation.definition.comment.cs"
+        end: "$\\n?"
+        name: "comment.block.documentation.cs"
+        patterns: [
           {
-            'include': '#constants'
-          }
-          {
-            'include': '#preprocessor'
-          }
-          {
-            'include': '#builtinTypes'
-          }
-          {
-            'include': '#comments'
+            include: "text.xml"
           }
         ]
       }
       {
-        'begin': '(?=\\bnew\\s+)(?=[\\w<].*\\s+)(?=[^=]+\\()'
-        'end': '(?={|;)'
-        'name': 'meta.new-object.cs'
-        'patterns': [
+        begin: "/\\*"
+        captures:
+          "0":
+            name: "punctuation.definition.comment.cs"
+        end: "\\*/\\n?"
+        name: "comment.block.cs"
+      }
+      {
+        begin: "//"
+        captures:
+          "1":
+            name: "punctuation.definition.comment.cs"
+        end: "$\\n?"
+        name: "comment.line.double-slash.cs"
+      }
+    ]
+  constants:
+    patterns: [
+      {
+        match: "\\b(true|false|null|this|base)\\b"
+        name: "constant.language.cs"
+      }
+      {
+        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+        name: "constant.numeric.cs"
+      }
+      {
+        captures:
+          "0":
+            name: "punctuation.definition.string.begin.cs"
+        match: "@\"([^\"]|\"\")*\""
+        name: "string.quoted.double.literal.cs"
+      }
+      {
+        begin: "\""
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.cs"
+        end: "\""
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.cs"
+        name: "string.quoted.double.cs"
+        patterns: [
           {
-            'include': '#code'
+            match: "\\\\."
+            name: "constant.character.escape.cs"
           }
         ]
       }
       {
-        'begin': '(?<!=|=\\s)(?!new)(?!.*(=|\\/\\/|\\/\\*).*\\()(?=[\\w<].*\\s+.+\\()'
-        'end': '(})|(?=;)'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.section.method.end.cs'
-        'name': 'meta.method.cs'
-        'patterns': [
+        begin: "'"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.cs"
+        end: "'"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.cs"
+        name: "string.quoted.single.cs"
+        patterns: [
           {
-            'include': '#storage-modifiers'
+            match: "\\\\."
+            name: "constant.character.escape.cs"
+          }
+        ]
+      }
+    ]
+  keywords:
+    patterns: [
+      {
+        match: "\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|when)\\b"
+        name: "keyword.control.cs"
+      }
+      {
+        match: "\\b(from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending)\\b"
+        name: "keyword.linq.cs"
+      }
+      {
+        match: "\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|nameof)\\b"
+        name: "keyword.operator.cs"
+      }
+      {
+        match: "\\b(event|delegate|fixed|add|remove|set|get|value|alias|global)\\b"
+        name: "keyword.other.cs"
+      }
+      {
+        match: "\\b(var)\\b"
+        name: "storage.type.var.cs"
+      }
+      {
+        match: "[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock |yield|await|nameof|when|alias|global)\\b"
+        name: "meta.class.body.cs"
+      }
+    ]
+  method:
+    patterns: [
+      {
+        begin: "\\["
+        end: "\\]"
+        name: "meta.method.annotation.cs"
+        patterns: [
+          {
+            include: "#constants"
           }
           {
-            'include': '#builtinTypes'
+            include: "#preprocessor"
           }
           {
-            'begin': '([\\w.]+)\\s*\\('
-            'beginCaptures':
-              '1':
-                'name': 'entity.name.function.cs'
-            'end': '\\)'
-            'name': 'meta.method.identifier.cs'
-            'patterns': [
+            include: "#builtinTypes"
+          }
+          {
+            include: "#comments"
+          }
+        ]
+      }
+      {
+        begin: "(?=\\bnew\\s+)(?=[\\w<].*\\s+)(?=[^=]+\\()"
+        end: "(?={|;)"
+        name: "meta.new-object.cs"
+        patterns: [
+          {
+            include: "#code"
+          }
+        ]
+      }
+      {
+        begin: "(?<!=|=\\s)(?!new)(?!.*(=|\\/\\/|\\/\\*).*\\()(?=[\\w<].*\\s+.+\\()"
+        end: "(})|(?=;)"
+        endCaptures:
+          "1":
+            name: "punctuation.section.method.end.cs"
+        name: "meta.method.cs"
+        patterns: [
+          {
+            include: "#storage-modifiers"
+          }
+          {
+            include: "#builtinTypes"
+          }
+          {
+            begin: "([\\w.]+)\\s*\\("
+            beginCaptures:
+              "1":
+                name: "entity.name.function.cs"
+            end: "\\)"
+            name: "meta.method.identifier.cs"
+            patterns: [
               {
-                'include': '#parameters'
+                include: "#parameters"
               }
               {
-                'include': '#constants'
+                include: "#constants"
               }
               {
-                'include': '#comments'
+                include: "#comments"
               }
               {
-                'include': '#builtinTypes'
+                include: "#builtinTypes"
               }
             ]
           }
           {
-            'begin': '(?=\\w.*\\s+[\\w.]+\\s*\\()'
-            'end': '(?=[\\w.]+\\s*\\()'
-            'name': 'meta.method.return-type.cs'
-            'patterns': [
+            begin: "(?=\\w.*\\s+[\\w.]+\\s*\\()"
+            end: "(?=[\\w.]+\\s*\\()"
+            name: "meta.method.return-type.cs"
+            patterns: [
               {
-                'include': '#builtinTypes'
+                include: "#builtinTypes"
               }
             ]
           }
           {
-            'begin': ':\\s*(this|base)\\s*\\('
-            'beginCaptures':
-              '1':
-                'name': 'constant.language.cs'
-            'end': '\\)'
-            'name': 'meta.method.base-call.cs'
-            'patterns': [
+            begin: ":\\s*(this|base)\\s*\\("
+            beginCaptures:
+              "1":
+                name: "constant.language.cs"
+            end: "\\)"
+            name: "meta.method.base-call.cs"
+            patterns: [
               {
-                'include': '#builtinTypes'
+                include: "#builtinTypes"
               }
             ]
           }
           {
-            'include': '#comments'
+            include: "#comments"
           }
           {
-            'begin': '{'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.method.begin.cs'
-            'end': '(?=})'
-            'name': 'meta.method.body.cs'
-            'patterns': [
+            begin: "{"
+            beginCaptures:
+              "0":
+                name: "punctuation.section.method.begin.cs"
+            end: "(?=})"
+            name: "meta.method.body.cs"
+            patterns: [
               {
-                'include': '#code'
+                include: "#code"
               }
             ]
           }
         ]
       }
       {
-        'begin': '(?!new)(?=[\\w<].*\\s+)(?=[^=]+\\{)'
-        'end': '}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.property.end.cs'
-        'name': 'meta.property.cs'
-        'patterns': [
+        begin: "(?!new)(?=[\\w<].*\\s+)(?=[^=]+\\{)"
+        end: "}"
+        endCaptures:
+          "0":
+            name: "punctuation.section.property.end.cs"
+        name: "meta.property.cs"
+        patterns: [
           {
-            'include': '#storage-modifiers'
+            include: "#storage-modifiers"
           }
           {
-            'begin': '([\\w.]+)\\s*(?={)'
-            'captures':
-              '1':
-                'name': 'entity.name.function.cs'
-            'end': '(?={)'
-            'name': 'meta.method.identifier.cs'
+            begin: "([\\w.]+)\\s*(?={)"
+            captures:
+              "1":
+                name: "entity.name.function.cs"
+            end: "(?={)"
+            name: "meta.method.identifier.cs"
           }
           {
-            'begin': '(?=\\w.*\\s+[\\w.]+\\s*\\{)'
-            'end': '(?=[\\w.]+\\s*\\{)'
-            'name': 'meta.method.return-type.cs'
-            'patterns': [
+            begin: "(?=\\w.*\\s+[\\w.]+\\s*\\{)"
+            end: "(?=[\\w.]+\\s*\\{)"
+            name: "meta.method.return-type.cs"
+            patterns: [
               {
-                'include': '#builtinTypes'
+                include: "#builtinTypes"
               }
             ]
           }
           {
-            'begin': '{'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.section.property.begin.cs'
-            'end': '(?=})'
-            'name': 'meta.method.body.cs'
-            'patterns': [
+            begin: "{"
+            beginCaptures:
+              "0":
+                name: "punctuation.section.property.begin.cs"
+            end: "(?=})"
+            name: "meta.method.body.cs"
+            patterns: [
               {
-                'include': '#code'
+                include: "#code"
               }
             ]
           }
         ]
       }
     ]
-  'method-call':
-    'begin': '([\\w$]+)\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'meta.method.cs'
-      '2':
-        'name': 'punctuation.definition.method-parameters.begin.cs'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.method-parameters.end.cs'
-    'name': 'meta.method-call.cs'
-    'patterns': [
+  "method-call":
+    begin: "([\\w$]+)\\s*(\\()"
+    beginCaptures:
+      "1":
+        name: "meta.method.cs"
+      "2":
+        name: "punctuation.definition.method-parameters.begin.cs"
+    end: "\\)"
+    endCaptures:
+      "0":
+        name: "punctuation.definition.method-parameters.end.cs"
+    name: "meta.method-call.cs"
+    patterns: [
       {
-        'match': ','
-        'name': 'punctuation.definition.seperator.parameter.cs'
+        match: ","
+        name: "punctuation.definition.seperator.parameter.cs"
       }
       {
-        'include': '#code'
-      }
-    ]
-  'parameters':
-    'begin': '\\b(ref|params|out)?\\s*\\b([\\w.\\[\\]]+)\\s+(\\w+)\\s*(=)?'
-    'beginCaptures':
-      '1':
-        'name': 'storage.type.modifier.cs'
-      '2':
-        'name': 'storage.type.generic.cs'
-      '3':
-        'name': 'variable.parameter.function.cs'
-      '4':
-        'name': 'keyword.operator.assignment.cs'
-    'end': '(?:(,)|(?=[\\)]))'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.separator.parameter.cs'
-    'patterns': [
-      {
-        'include': '#constants'
-      }
-      {
-        'include': '#block'
-      }
-      {
-        'include': '#builtinTypes'
+        include: "#code"
       }
     ]
-  'preprocessor':
-    'patterns': [
+  parameters:
+    begin: "\\b(ref|params|out)?\\s*\\b([\\w.\\[\\]]+)\\s+(\\w+)\\s*(=)?"
+    beginCaptures:
+      "1":
+        name: "storage.type.modifier.cs"
+      "2":
+        name: "storage.type.generic.cs"
+      "3":
+        name: "variable.parameter.function.cs"
+      "4":
+        name: "keyword.operator.assignment.cs"
+    end: "(?:(,)|(?=[\\)]))"
+    endCaptures:
+      "1":
+        name: "punctuation.definition.separator.parameter.cs"
+    patterns: [
       {
-        'captures':
-          '1':
-            'name': 'directive.preprocessor.cs'
-          '3':
-            'name': 'entity.name.function.preprocessor.cs'
-        'match': '^\\s*(#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion))\\b\\s*(.*?)(?=$|\\/\\/)'
-        'name': 'meta.preprocessor.cs'
+        include: "#constants"
+      }
+      {
+        include: "#block"
+      }
+      {
+        include: "#builtinTypes"
       }
     ]
-  'storage-modifiers':
-    'match': '\\b(event|delegate|internal|public|protected|private|static|const|new|sealed|abstract|virtual|override|extern|unsafe|readonly|volatile|implicit|explicit|operator|async|partial|alias)\\b'
-    'name': 'storage.modifier.cs'
+  preprocessor:
+    patterns: [
+      {
+        captures:
+          "1":
+            name: "directive.preprocessor.cs"
+          "3":
+            name: "entity.name.function.preprocessor.cs"
+        match: "^\\s*(#\\s*(if|else|elif|endif|define|undef|warning|error|line|pragma|region|endregion))\\b\\s*(.*?)(?=$|\\/\\/)"
+        name: "meta.preprocessor.cs"
+      }
+    ]
+  "storage-modifiers":
+    match: "\\b(event|delegate|internal|public|protected|private|static|const|new|sealed|abstract|virtual|override|extern|unsafe|readonly|volatile|implicit|explicit|operator|async|partial|alias)\\b"
+    name: "storage.modifier.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -294,7 +294,7 @@ repository:
         name: "storage.type.var.cs"
       }
       {
-        match: "[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof |override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending |if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock |yield|await|nameof|when|alias|global)\\b"
+        match: "[@]\\b(var|event|delegate|add|remove|set|get|value|new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|from|where|select|group|into|orderby|join|let|on|equals|by|ascending|descending|if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|nameof|when|alias|global)\\b"
         name: "meta.class.body.cs"
       }
     ]

--- a/grammars/cake.cson
+++ b/grammars/cake.cson
@@ -1,14 +1,14 @@
-'scopeName': 'source.cake'
-'name': 'C# Cake File'
-'fileTypes': [
-  'cake'
+scopeName: "source.cake"
+name: "C# Cake File"
+fileTypes: [
+  "cake"
 ]
-'patterns': [
+patterns: [
   {
-    'include': 'source.cs'
+    include: "source.cs"
   }
   {
-    'match': '^#(load|l)'
-    'name': 'preprocessor.source.cake'
+    match: "^#(load|l)"
+    name: "preprocessor.source.cake"
   }
 ]

--- a/grammars/csx.cson
+++ b/grammars/csx.cson
@@ -1,14 +1,14 @@
-'scopeName': 'source.csx'
-'name': 'C# Script File'
-'fileTypes': [
-  'csx'
+scopeName: "source.csx"
+name: "C# Script File"
+fileTypes: [
+  "csx"
 ]
-'patterns': [
+patterns: [
   {
-    'include': 'source.cs'
+    include: "source.cs"
   }
   {
-    'match': '^#(load|r)'
-    'name': 'preprocessor.source.csx'
+    match: "^#(load|r)"
+    name: "preprocessor.source.csx"
   }
 ]

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -124,7 +124,7 @@ describe "Language C# package", ->
         'class B {\npublic bool Prop {\nget{\n$preprocessor\nreturn true;\n}\n}' ]
       leadings = [ '    ', ' ', '\t\t' ]
 
-      it "parses in correct locations", =>
+      it "parses in correct locations", ->
         for directive in directives
           for location in locations
             tokens = grammar.tokenizeLines location.replace '$preprocessor', directive
@@ -142,7 +142,7 @@ describe "Language C# package", ->
             else
               expect(token[0].value).toBe(directive)
 
-      it "parses in correct locations with leading whitespace", =>
+      it "parses in correct locations with leading whitespace", ->
         for directive in directives
           for location in locations
             for leading in leadings
@@ -161,7 +161,7 @@ describe "Language C# package", ->
               else
                 expect(token[1].value).toBe(directive)
 
-      it "parses in correct locations with trailing line comment", =>
+      it "parses in correct locations with trailing line comment", ->
         for directive in directives
           for location in locations
             tokens = grammar.tokenizeLines location.replace '$preprocessor', (directive + ' // A line comment')


### PR DESCRIPTION
Removes the single quotes from keynames and uses double-quotes for values. This is the default format for the season/CSON library we use and these files were converted using;

```json
convert = (f) => season.writeFileSync(f, season.readFileSync(f))
```

1. Easier to read (Atom highlights keys differently from the string values)
2. Easier to edit (less typing)
3. Easier to merge with other textmate-derived grammars in json format