### PR TITLE
Sync up language-csharp with work on other derivations

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,6 +21,20 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------
+
 This package was derived from a TextMate bundle located at
 https://github.com/wintermi/csharp-tmbundle by Matthew Winter @wintermi and
 Adam Lickel @lickel and distributed under the following license, located in
@@ -31,5 +45,4 @@ This bundle is dual-licensed under MIT and GPL licenses.
  - http://www.opensource.org/licenses/mit-license.php
  - http://www.gnu.org/licenses/gpl.html
 
-Use it, change it, fork it, sell it. Do what you will, but please leave the
-author attribution.
+Use it, change it, fork it, sell it. Do what you will, but please leave the author attribution.

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -479,7 +479,7 @@ repository:
         name: "constant.language.cs"
       }
       {
-        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(?i:f|d|m|u|l|ul|lu)?\\b"
         name: "constant.numeric.cs"
       }
       {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -19,7 +19,7 @@ patterns: [
 repository:
   using:
     begin: "^\\s*(using)\\b\\s+(static)?\\b\\s*([\\w.]+)"
-    captures:
+    beginCaptures:
       "1":
         name: "keyword.other.using.cs"
       "2":
@@ -563,7 +563,7 @@ repository:
       }
     ]
   parameters:
-    begin: "\\b(ref|params|out)?\\s*\\b([\\w.\\[\\]]+)\\s+(\\w+)\\s*(=)?"
+    begin: "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*(=)?"
     beginCaptures:
       "1":
         name: "storage.type.modifier.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -62,6 +62,21 @@ repository:
         ]
       }
     ]
+  variable:
+    patterns: [
+      {
+        match: "^\\s*\\b(var)\\s+(.*?)(?=(=|;))"
+        captures:
+          "1":
+            name: "keyword.other.var.cs"
+      }
+      {
+        match: "^\\s*\\b(?!var|return|yield|throw)([\\w<>*?\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
+        captures:
+          "1":
+            name: "storage.type.variable.cs"
+      }
+    ]
   block:
     patterns: [
       {
@@ -164,6 +179,9 @@ repository:
       }
       {
         include: "#class"
+      }
+      {
+        include: "#variable"
       }
       {
         include: "#constants"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -62,6 +62,42 @@ repository:
         ]
       }
     ]
+  "field-declaration":
+    patterns: [
+      {
+        begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event)\\s*)*)(?:[\\w\\s,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
+        end: "(?=;)"
+        patterns: [
+          {
+            match: "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
+            captures:
+              "1":
+                patterns: [
+                  {
+                    include: "#storage-modifiers"
+                  }
+                ]
+              "2":
+                patterns: [
+                  {
+                    include: "#type"
+                  }
+                ]
+              "3":
+                name: "entity.name.variable.cs"
+          }
+          {
+            begin: "(?==>?)"
+            end: "(?=;|$)"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   variable:
     patterns: [
       {
@@ -170,6 +206,9 @@ repository:
     patterns: [
       {
         include: "type-declaration"
+      }
+      {
+        include: "#field-declaration"
       }
       {
         include: "#method"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -153,6 +153,49 @@ repository:
         name: "storage.type.cs"
       }
     ]
+  type:
+    patterns: [
+      {
+        match: "([\\w\\.]+\\s*<(?:[\\w\\s,\\.`\\[\\]\\*]+|\\g<1>)+>(?:\\s*\\[\\s*\\])?)"
+        comment: "generic type"
+        captures:
+          "1":
+            name: "storage.type.cs"
+      }
+      {
+        match: "\\b([a-zA-Z]+[\\w\\.]*\\b(?:\\s*\\[\\s*\\])?\\*?)"
+        comment: "non-generic type"
+        captures:
+          "1":
+            name: "storage.type.cs"
+      }
+    ]
+  "generic-constraints":
+    begin: "(where)\\s+(\\w+)\\s*:"
+    end: "(?=where|{|$)"
+    beginCaptures:
+      "1":
+        name: "keyword.other.cs"
+      "2":
+        name: "storage.type.cs"
+    patterns: [
+      {
+        match: "\\b(class|struct)\\b"
+        name: "keyword.other.cs"
+      }
+      {
+        match: "(new)\\s*\\(\\s*\\)"
+        captures:
+          "1":
+            name: "keyword.other.cs"
+      }
+      {
+        include: "#type"
+      }
+      {
+        include: "#generic-constraints"
+      }
+    ]
   "type-declaration":
     begin: "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)"
     end: "}"
@@ -168,25 +211,35 @@ repository:
         include: "#comments"
       }
       {
-        captures:
+        begin: "(class|struct|interface|enum)\\s+"
+        end: "(?={|:|$|where)"
+        name: "meta.class.identifier.cs"
+        beginCaptures:
           "1":
             name: "storage.modifier.cs"
-          "2":
-            name: "entity.name.type.class.cs"
-        match: "(class|struct|interface|enum)\\s+(\\w+)"
-        name: "meta.class.identifier.cs"
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
       }
       {
         begin: ":"
-        end: "(?={)"
+        end: "(?={|where)"
         patterns: [
           {
+            include: "#type"
+          }
+          {
+            match: "([\\w<>]+)\\s*"
             captures:
               "1":
                 name: "storage.type.cs"
-            match: "\\s*,?([A-Za-z_]\\w*)\\b"
           }
         ]
+      }
+      {
+        include: "#generic-constraints"
       }
       {
         begin: "{"
@@ -205,7 +258,7 @@ repository:
   "type-body":
     patterns: [
       {
-        include: "type-declaration"
+        include: "#type-declaration"
       }
       {
         include: "#field-declaration"
@@ -541,7 +594,7 @@ repository:
             include: "#builtinTypes"
           }
           {
-            begin: "([\\w.]+)\\s*\\("
+            begin: "([\\w]+\\s*(?:<[\\w<>\\s,`?]*>)?)\\s*\\("
             beginCaptures:
               "1":
                 name: "entity.name.function.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -117,7 +117,7 @@ repository:
         name: "storage.type.cs"
       }
     ]
-  class:
+  "type-declaration":
     begin: "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)"
     end: "}"
     endCaptures:
@@ -161,12 +161,24 @@ repository:
         name: "meta.class.body.cs"
         patterns: [
           {
-            include: "#method"
-          }
-          {
-            include: "#code"
+            include: "#type-body"
           }
         ]
+      }
+    ]
+  "type-body":
+    patterns: [
+      {
+        include: "type-declaration"
+      }
+      {
+        include: "#method"
+      }
+      {
+        include: "#storage-modifiers"
+      }
+      {
+        include: "#code"
       }
     ]
   code:
@@ -178,7 +190,7 @@ repository:
         include: "#comments"
       }
       {
-        include: "#class"
+        include: "#type-declaration"
       }
       {
         include: "#variable"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -642,6 +642,19 @@ repository:
             include: "#comments"
           }
           {
+            begin: "=>"
+            beginCaptures:
+              "0":
+                name: "punctuation.section.method.begin.cs"
+            end: "(?=;)"
+            name: "meta.method.body.cs"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
             begin: "{"
             beginCaptures:
               "0":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -406,26 +406,28 @@ repository:
         name: "meta.class.body.cs"
       }
     ]
+  attribute:
+    begin: "\\["
+    end: "\\]"
+    name: "meta.method.annotation.cs"
+    patterns: [
+      {
+        include: "#constants"
+      }
+      {
+        include: "#preprocessor"
+      }
+      {
+        include: "#builtinTypes"
+      }
+      {
+        include: "#comments"
+      }
+    ]
   method:
     patterns: [
       {
-        begin: "\\["
-        end: "\\]"
-        name: "meta.method.annotation.cs"
-        patterns: [
-          {
-            include: "#constants"
-          }
-          {
-            include: "#preprocessor"
-          }
-          {
-            include: "#builtinTypes"
-          }
-          {
-            include: "#comments"
-          }
-        ]
+        include: "#attribute"
       }
       {
         begin: "(?=\\bnew\\s+)(?=[\\w<].*\\s+)(?=[^=]+\\()"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -19,7 +19,7 @@ patterns: [
 repository:
   using:
     begin: "^\\s*(using)\\b\\s+(static)?\\b\\s*([\\w.]+)"
-    beginCaptures:
+    captures:
       "1":
         name: "keyword.other.using.cs"
       "2":
@@ -28,7 +28,7 @@ repository:
         name: "entity.name.type.namespace.cs"
     end: "\\s*(?:$|(;))"
   namespace:
-    begin: "^\\s*((namespace)\\s+([\\w.]+))"
+    begin: "^\\s*[^@]?((namespace)\\s+([\\w.]+))"
     beginCaptures:
       "1":
         name: "meta.namespace.identifier.cs"
@@ -103,7 +103,7 @@ repository:
       }
     ]
   class:
-    begin: "(?=\\w?[\\w\\s]*(?:class|struct|interface|enum)\\s+\\w+)"
+    begin: "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)"
     end: "}"
     endCaptures:
       "0":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -219,15 +219,91 @@ repository:
         name: "comment.line.double-slash.cs"
       }
     ]
-  constants:
+  "string-interpolated":
     patterns: [
       {
-        match: "\\b(true|false|null|this|base)\\b"
-        name: "constant.language.cs"
+        begin: "\\$\""
+        end: "\"|$"
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.cs"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.cs"
+        patterns: [
+          {
+            begin: "([^{}]+?)(?={|\"|$)"
+            end: "(?={|\"|$)"
+            beginCaptures:
+              "1":
+                name: "string.quoted.double.cs"
+          }
+          {
+            begin: "{"
+            end: "}"
+            name: "meta.interpolated.expression.cs"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
+            begin: "([^{}]+?)(?={|\"|$)"
+            end: "(?={|\"|$)"
+            beginCaptures:
+              "1":
+                name: "string.quoted.double.cs"
+          }
+        ]
+      }
+    ]
+  "string-interpolated-verbatim":
+    patterns: [
+      {
+        begin: "\\$@\""
+        end: "\""
+        beginCaptures:
+          "0":
+            name: "punctuation.definition.string.begin.cs"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.string.end.cs"
+        patterns: [
+          {
+            begin: "([^{}]+?)(?={|\"|$)"
+            end: "(?={|\"|$)"
+            beginCaptures:
+              "1":
+                name: "string.quoted.double.literal.cs"
+          }
+          {
+            begin: "{"
+            end: "}"
+            name: "meta.interpolated.expression.cs"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
+            begin: "([^{}]+?)(?={|\"|$)"
+            end: "(?={|\"|$)"
+            beginCaptures:
+              "1":
+                name: "string.quoted.double.literal.cs"
+          }
+        ]
+      }
+    ]
+  string:
+    patterns: [
+      {
+        include: "#string-interpolated-verbatim"
       }
       {
-        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
-        name: "constant.numeric.cs"
+        include: "#string-interpolated"
       }
       {
         captures:
@@ -269,6 +345,20 @@ repository:
             name: "constant.character.escape.cs"
           }
         ]
+      }
+    ]
+  constants:
+    patterns: [
+      {
+        match: "\\b(true|false|null|this|base)\\b"
+        name: "constant.language.cs"
+      }
+      {
+        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+        name: "constant.numeric.cs"
+      }
+      {
+        include: "#string"
       }
     ]
   keywords:

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -211,6 +211,9 @@ repository:
         include: "#field-declaration"
       }
       {
+        include: "#property-declaration"
+      }
+      {
         include: "#method"
       }
       {
@@ -475,6 +478,39 @@ repository:
         include: "#comments"
       }
     ]
+  "property-declaration":
+    begin: "^\\s*(?!.*\\b(?:class|interface|struct)\\b)((?:\\w+\\s+)*?)(?!(?:private|public|internal|protected|static|new|virtual|override))(\\w.+?)\\s+(\\w+)\\s*(?={|$)"
+    end: "}|;|$"
+    beginCaptures:
+      "1":
+        patterns: [
+          {
+            include: "#storage-modifiers"
+          }
+        ]
+      "2":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+      "3":
+        name: "entity.name.function.cs"
+    name: "meta.property.cs"
+    patterns: [
+      {
+        include: "#block"
+      }
+      {
+        begin: "="
+        end: "(?=;)"
+        patterns: [
+          {
+            include: "#code"
+          }
+        ]
+      }
+    ]
   method:
     patterns: [
       {
@@ -557,50 +593,6 @@ repository:
             beginCaptures:
               "0":
                 name: "punctuation.section.method.begin.cs"
-            end: "(?=})"
-            name: "meta.method.body.cs"
-            patterns: [
-              {
-                include: "#code"
-              }
-            ]
-          }
-        ]
-      }
-      {
-        begin: "(?!new)(?=[\\w<].*\\s+)(?=[^=]+\\{)"
-        end: "}"
-        endCaptures:
-          "0":
-            name: "punctuation.section.property.end.cs"
-        name: "meta.property.cs"
-        patterns: [
-          {
-            include: "#storage-modifiers"
-          }
-          {
-            begin: "([\\w.]+)\\s*(?={)"
-            captures:
-              "1":
-                name: "entity.name.function.cs"
-            end: "(?={)"
-            name: "meta.method.identifier.cs"
-          }
-          {
-            begin: "(?=\\w.*\\s+[\\w.]+\\s*\\{)"
-            end: "(?=[\\w.]+\\s*\\{)"
-            name: "meta.method.return-type.cs"
-            patterns: [
-              {
-                include: "#builtinTypes"
-              }
-            ]
-          }
-          {
-            begin: "{"
-            beginCaptures:
-              "0":
-                name: "punctuation.section.property.begin.cs"
             end: "(?=})"
             name: "meta.method.body.cs"
             patterns: [

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -22,18 +22,18 @@ describe "Language C# package", ->
       }
       """
 
-      expect(tokens[1][1]).toEqual value: 'byte ', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
-      expect(tokens[1][3]).toEqual value: '//', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
-      expect(tokens[1][4]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.type.cs']
+      expect(tokens[1][5]).toEqual value: '//', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
 
       tokens = grammar.tokenizeLines """
       struct hi {
         byte q; /*(*/
       }
       """
-      expect(tokens[1][1]).toEqual value: 'byte ', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
-      expect(tokens[1][3]).toEqual value: '/*', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs', 'punctuation.definition.comment.cs']
-      expect(tokens[1][4]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.type.cs']
+      expect(tokens[1][5]).toEqual value: '/*', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs', 'punctuation.definition.comment.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs']
 
     it "tokenizes method definitions correctly", ->
       {tokens} = grammar.tokenizeLine("void func()")
@@ -74,13 +74,13 @@ describe "Language C# package", ->
         })
       """
 
-      expect(tokens[1][3]).toEqual value: 'C', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[1][4]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
-      expect(tokens[1][5]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
-      expect(tokens[1][6]).toEqual value: '1.1 10', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs']
-      expect(tokens[1][7]).toEqual value: '\\n', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'constant.character.escape.cs']
-      expect(tokens[1][8]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
-      expect(tokens[1][9]).toEqual value: ')', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.end.cs']
+      expect(tokens[1][5]).toEqual value: 'C', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      expect(tokens[1][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
+      expect(tokens[1][8]).toEqual value: '1.1 10', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs']
+      expect(tokens[1][9]).toEqual value: '\\n', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'constant.character.escape.cs']
+      expect(tokens[1][10]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
+      expect(tokens[1][11]).toEqual value: ')', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.end.cs']
 
     it "tokenizes strings in classes", ->
       tokens = grammar.tokenizeLines """
@@ -90,10 +90,10 @@ describe "Language C# package", ->
         }
       """
 
-      expect(tokens[2][5]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
-      expect(tokens[2][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs']
-      expect(tokens[2][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
-      expect(tokens[2][8]).toEqual value: ';', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs']
+      expect(tokens[2][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
+      expect(tokens[2][8]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs']
+      expect(tokens[2][9]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
+      expect(tokens[2][10]).toEqual value: ';', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs']
 
       tokens = grammar.tokenizeLines """
         class a


### PR DESCRIPTION
Brings in changes from some other repos that have continued work on the C# syntax.

## Fixes

- String interpolation: fixes #43 (supersedes and closes #49)
- Nullable types: fixes #58 
- Not treating keywords with @ in front of them as keywords (in some places)

## Improves

- Generic type parameters and constraints for type declarations
- Property, field and variable declarations

