### PR TITLE
Add d, m; remove invalid ll, ull suffixes

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -226,7 +226,7 @@ repository:
         name: "constant.language.cs"
       }
       {
-        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(?i:f|d|m|u|l|ul|lu)?\\b"
         name: "constant.numeric.cs"
       }
       {


### PR DESCRIPTION
And make the suffixes case insensitive, fixes #77 I think.

Before | After
:-------------------------:|:-------------------------:
![](http://i.imgur.com/6GBGCrt.png)  |  ![](http://i.imgur.com/muf8nSH.png)