### PR TITLE
Correct scope name spelling in 'method-call' pattern

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -702,7 +702,7 @@ repository:
     patterns: [
       {
         match: ","
-        name: "punctuation.definition.seperator.parameter.cs"
+        name: "punctuation.definition.separator.parameter.cs"
       }
       {
         include: "#code"


### PR DESCRIPTION
### Description of the Change

Corrected spelling of _separator_ portion of scope name in `method-call` pattern:

**Before**
```
  "method-call":
   ...
    patterns: [
      {
        match: ","
        name: "punctuation.definition.seperator.parameter.cs"
      }
```

**After**
```
  "method-call":
   ...
    patterns: [
      {
        match: ","
        name: "punctuation.definition.separator.parameter.cs"
      }
```

## Alternate Designs

All other occurrences of this scope name have the correct spelling of _separator_.

### Benefits

Consistent spelling of scope names.

### Possible Drawbacks

Will affect code trying to match incorrectly spelled scope.

### Applicable Issues

n/a
