### PR TITLE
Massive overhaul of grammar

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -119,6 +119,24 @@ repository:
         name: "meta.field.declaration.cs"
         patterns: [
           {
+            begin: "(?==>?)"
+            end: "(?=;|$)"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
+            begin: "\\s*=\\s*"
+            end: "(?=;)"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
             match: "\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
             captures:
               "1":
@@ -131,15 +149,6 @@ repository:
                 ]
               "3":
                 name: "entity.name.variable.cs"
-          }
-          {
-            begin: "(?==>?)"
-            end: "(?=;|$)"
-            patterns: [
-              {
-                include: "#code"
-              }
-            ]
           }
         ]
       }

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -140,6 +140,14 @@ repository:
             name: "keyword.other.var.cs"
       }
       {
+        match: "(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)"
+        captures:
+          "1":
+            patterns: [
+              {
+                include: "#type"
+              }
+            ]
       }
       {
         match: "^\\s*\\b(?!var|return|yield|throw)([\\w+<>*?,\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -229,8 +229,13 @@ repository:
         ]
       }
       {
+        match: "\\b(I[A-Z]+[\\w\\.]*)\\s*(?:\\s*\\[\\s*\\])?\\*?\\b"
+        captures:
+          "1":
+            name: "meta.class.interface.identifier.cs"
+      }
+      {
         match: "\\b([a-zA-Z]+[\\w\\.]*)\\s*(?:\\s*\\[\\s*\\])?\\*?\\b"
-        comment: "non-generic type"
         captures:
           "1":
             name: "meta.class.identifier.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -817,10 +817,10 @@ repository:
         name: "meta.method.cs"
         patterns: [
           {
-            begin: "([\\w]+)\\s*(<[\\w<>\\s,`?]*>)?\\s*\\("
+            begin: "([\\w]+)\\s*(<[\\w<>\\s,`?]*>)?\\s*(\\()"
             beginCaptures:
               "1":
-                name: "entity.name.function.cs"
+                name: "entity.name.function.declaration.cs"
               "2":
                 name: "meta.generic.method.identifier"
                 patterns: [
@@ -839,7 +839,12 @@ repository:
                         ]
                   }
                 ]
+              "3":
+                name: "punctuation.definition.method-parameters.begin.cs"
             end: "\\)"
+            endCaptures:
+              "0":
+                name: "punctuation.definition.method-parameters.end.cs"
             name: "meta.method.identifier.cs"
             patterns: [
               {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -187,14 +187,14 @@ repository:
   builtinTypes:
     patterns: [
       {
-        match: "(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)[ ]*(\\?|\\*)?"
+        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)[ ]*(\\?|\\*)?\\b"
         name: "storage.value.type.cs"
         captures:
           "2":
             name: "punctuation.storage.type.modifier.cs"
       }
       {
-        match: "(dynamic|object|string)[ ]*([*])?"
+        match: "\\b(dynamic|object|string)[ ]*([*])?\\b"
         name: "storage.reference.type.cs"
         captures:
           "2":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -105,7 +105,7 @@ repository:
               "2":
                 patterns: [
                   {
-                    include: "#type"
+                    include: "#typeName"
                   }
                 ]
               "3":
@@ -174,7 +174,7 @@ repository:
             name: "punctuation.storage.type.modifier.cs"
       }
     ]
-  type:
+  typeName:
     patterns: [
       {
         match: "([\\w\\.]+\\s*<(?:[\\w\\s,\\.`\\[\\]\\*]+|\\g<1>)+>(?:\\s*\\[\\s*\\])?)"
@@ -211,7 +211,7 @@ repository:
             name: "keyword.other.cs"
       }
       {
-        include: "#type"
+        include: "#typeName"
       }
       {
         include: "#generic-constraints"
@@ -240,7 +240,7 @@ repository:
             name: "storage.modifier.cs"
         patterns: [
           {
-            include: "#type"
+            include: "#typeName"
           }
         ]
       }
@@ -249,7 +249,7 @@ repository:
         end: "(?={|where)"
         patterns: [
           {
-            include: "#type"
+            include: "#typeName"
           }
           {
             match: "([\\w<>]+)\\s*"
@@ -557,7 +557,7 @@ repository:
       "2":
         patterns: [
           {
-            include: "#type"
+            include: "#typeName"
           }
         ]
       "3":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -353,8 +353,40 @@ repository:
         include: "#code"
       }
     ]
+  typeOperator:
+    patterns: [
+      {
+        include: "#keywordTypeOperator"
+      }
+      {
+        include: "#castTypeOperator"
+      }
+    ]
+  castTypeOperator:
+    match: "\\((\\w+[?*,<>\\[\\]]*)\\)"
+    captures:
+      "1":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+  keywordTypeOperator:
+    match: "\\b(is|as|new)\\s+(\\w+[?*,<>\\[\\]]*)"
+    captures:
+      "1":
+        name: "keyword.operator.cs"
+      "2":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
   code:
     patterns: [
+      {
+        include: "#typeOperator"
+      }
       {
         include: "#block"
       }

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -168,7 +168,7 @@ repository:
   returnType:
     patterns: [
       {
-        match: "\\bvoid\\b"
+        match: "void"
         name: "storage.type.cs"
       }
       {
@@ -187,14 +187,14 @@ repository:
   builtinTypes:
     patterns: [
       {
-        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)\\s*(\\?|\\*)?\\s*\\b"
+        match: "(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)[ ]*(\\?|\\*)?"
         name: "storage.value.type.cs"
         captures:
           "2":
             name: "punctuation.storage.type.modifier.cs"
       }
       {
-        match: "\\b(dynamic|object|string)\\s*(\\*)?\\s*\\b"
+        match: "(dynamic|object|string)[ ]*([*])?"
         name: "storage.reference.type.cs"
         captures:
           "2":
@@ -214,7 +214,7 @@ repository:
             match: ","
           }
           {
-            match: "(\\w+)"
+            match: "(\\w+([?*])?)"
             captures:
               "1":
                 name: "meta.generic.type.specifier"
@@ -378,6 +378,11 @@ repository:
       }
       {
         include: "#method-call"
+      }
+      {
+        # This should be types but we need to further refine other rules or
+        # it will greedy consume variable names as type names.
+        include: "#builtinTypes"
       }
     ]
   comments:

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -90,11 +90,11 @@ repository:
   "field-declaration":
     patterns: [
       {
-        begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event)\\s*)*)(?:[\\w\\s,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
+        begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)(?:[\\w\\s,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
         end: "(?=;)"
         patterns: [
           {
-            match: "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
+            match: "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
             captures:
               "1":
                 patterns: [

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -16,19 +16,10 @@ patterns: [
     include: "#namespace"
   }
   {
-    include: "#comments"
+    include: "#code"
   }
   {
-    include: "#enum-declaration"
-  }
-  {
-    include: "#type-declaration"
-  }
-  {
-    include: "#preprocessor"
-  }
-  {
-    include: "#keywords"
+    include: "#method"
   }
 ]
 repository:
@@ -255,7 +246,7 @@ repository:
             match: "(\\w+([?*])?)"
             captures:
               "1":
-                name: "meta.generic.type.specifier"
+                name: "meta.generic.type.specifier.cs"
                 patterns: [
                   {
                     include: "#type"
@@ -285,7 +276,7 @@ repository:
       "1":
         name: "keyword.other.cs"
       "2":
-        name: "meta.generic.type.specifier"
+        name: "meta.generic.type.specifier.cs"
         patterns: [
           {
             include: "#type"
@@ -831,7 +822,7 @@ repository:
                     match: "(\\w+)"
                     captures:
                       "1":
-                        name: "meta.generic.type.specifier"
+                        name: "meta.generic.type.specifier.cs"
                         patterns: [
                           {
                             include: "#type"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -7,13 +7,25 @@ foldingStartMarker: "^\\s*#\\s*region|^\\s*/\\*|^(?![^{]*?//|[^{]*?/\\*(?!.*?\\*
 foldingStopMarker: "^\\s*#\\s*endregion|^\\s*\\*/|^\\s*\\}"
 patterns: [
   {
+    include: "#attribute"
+  }
+  {
     include: "#using"
   }
   {
     include: "#namespace"
   }
   {
-    include: "#code"
+    include: "#comments"
+  }
+  {
+    include: "#type-declaration"
+  }
+  {
+    include: "#preprocessor"
+  }
+  {
+    include: "#keywords"
   }
 ]
 repository:
@@ -239,13 +251,17 @@ repository:
       }
     ]
   "type-declaration":
-    begin: "(?=\\w?[\\w\\s]*[^@]?(?:class|struct|interface|enum)\\s+\\w+)"
+    begin: "(?=(?:public|private|protected|internal|static|partial)?[^@](.*)?(?:class|struct|interface|enum)\\s+\\w+)"
     end: "}"
     endCaptures:
       "0":
         name: "punctuation.section.class.end.cs"
     name: "meta.class.cs"
     patterns: [
+      {
+        match: "\\b(public|private|protected|internal|static|partial)\\b"
+        name: "storage.modifier.cs"
+      }
       {
         include: "#comments"
       }
@@ -308,6 +324,9 @@ repository:
     ]
   "type-body":
     patterns: [
+      {
+        include: "#attribute"
+      }
       {
         include: "#type-declaration"
       }
@@ -594,9 +613,6 @@ repository:
     ]
   method:
     patterns: [
-      {
-        include: "#attribute"
-      }
       {
         begin: "(?=\\bnew\\s+)(?=[\\w<].*\\s+)(?=[^=]+\\()"
         end: "(?={|;)"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -165,6 +165,16 @@ repository:
         ]
       }
     ]
+  returnType:
+    patterns: [
+      {
+        match: "\\bvoid\\b"
+        name: "storage.type.cs"
+      }
+      {
+        include: "#type"
+      }
+    ]
   type:
     patterns: [
       {
@@ -624,6 +634,37 @@ repository:
         ]
       }
       {
+        begin: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\s+(void|[\\w<>.?*\\[\\],]+)\\s+(?=.*=>\\s*)"
+        beginCaptures:
+          "1":
+            name: "storage.modifier.cs"
+          "2":
+            patterns: [
+              {
+                include: "#returnType"
+              }
+            ]
+        end: ";"
+        patterns: [
+          {
+            include: "#parameters"
+          }
+          {
+            begin: "=>"
+            beginCaptures:
+              "0":
+                name: "punctuation.section.method.begin.cs"
+            end: "(?=;)"
+            name: "meta.method.body.cs"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+        ]
+      }
+      {
         begin: "(?<!=|=\\s)(?!new)(?!.*(=|\\/\\/|\\/\\*).*\\()(?=[\\w<].*\\s+.+\\()"
         end: "(})|(?=;)"
         endCaptures:
@@ -636,11 +677,8 @@ repository:
             name: "storage.modifier.cs"
           }
           {
-            match: "\\bvoid\\b"
-            name: "storage.type.cs"
-          }
-          {
-            include: "#builtinTypes"
+            name: "meta.method.return-type.cs"
+            include: "#returnType"
           }
           {
             begin: "([\\w]+)\\s*(<[\\w<>\\s,`?]*>)?\\s*\\("
@@ -685,11 +723,7 @@ repository:
             name: "meta.method.return-type.cs"
             patterns: [
               {
-                match: "\\bvoid\\b"
-                name: "storage.type.cs"
-              }
-              {
-                include: "#builtinTypes"
+                include: "#returnType"
               }
             ]
           }
@@ -708,19 +742,6 @@ repository:
           }
           {
             include: "#comments"
-          }
-          {
-            begin: "=>"
-            beginCaptures:
-              "0":
-                name: "punctuation.section.method.begin.cs"
-            end: "(?=;)"
-            name: "meta.method.body.cs"
-            patterns: [
-              {
-                include: "#code"
-              }
-            ]
           }
           {
             begin: "{"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -105,7 +105,7 @@ repository:
               "2":
                 patterns: [
                   {
-                    include: "#typeName"
+                    include: "#type"
                   }
                 ]
               "3":
@@ -157,6 +157,15 @@ repository:
         ]
       }
     ]
+  type:
+    patterns: [
+      {
+        include: "#builtinTypes"
+      }
+      {
+        include: "#typeName"
+      }
+    ]
   builtinTypes:
     patterns: [
       {
@@ -188,7 +197,7 @@ repository:
         comment: "non-generic type"
         captures:
           "1":
-            name: "storage.type.cs"
+            name: "meta.class.identifier.cs"
       }
     ]
   "generic-constraints":
@@ -211,7 +220,7 @@ repository:
             name: "keyword.other.cs"
       }
       {
-        include: "#typeName"
+        include: "#type"
       }
       {
         include: "#generic-constraints"
@@ -234,13 +243,25 @@ repository:
       {
         begin: "(class|struct|interface|enum)\\s+"
         end: "(?={|:|$|where)"
-        name: "meta.class.identifier.cs"
         beginCaptures:
           "1":
-            name: "storage.modifier.cs"
+            name: "keyword.class.declaration.cs"
         patterns: [
           {
             include: "#typeName"
+          }
+          {
+            begin: "[<]\\s*"
+            end: "\\s*[>]"
+            name: "punctuation.type.specifiers.cs"
+            patterns: [
+              {
+                include: "#typeName"
+              }
+              {
+                match: ","
+              }
+            ]
           }
         ]
       }
@@ -289,9 +310,6 @@ repository:
       }
       {
         include: "#method"
-      }
-      {
-        include: "#storage-modifiers"
       }
       {
         include: "#code"
@@ -557,7 +575,7 @@ repository:
       "2":
         patterns: [
           {
-            include: "#typeName"
+            include: "#type"
           }
         ]
       "3":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -145,7 +145,7 @@ repository:
         match: "^\\s*\\b(?!var|return|yield|throw)([\\w+<>*?,\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
         captures:
           "1":
-            name: "storage.type.variable.cs.test-red"
+            name: "storage.type.variable.cs"
       }
     ]
   block:
@@ -710,7 +710,7 @@ repository:
                 include: "#returnType"
               }
             ]
-        end: "}"
+        end: "[};]"
         endCaptures:
           "1":
             name: "punctuation.section.method.end.cs"
@@ -775,6 +775,19 @@ repository:
               "0":
                 name: "punctuation.section.method.begin.cs"
             end: "(?=})"
+            name: "meta.method.body.cs"
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
+          }
+          {
+            begin: "=>"
+            beginCaptures:
+              "0":
+                name: "punctuation.section.method.begin.cs"
+            end: "(?=;)"
             name: "meta.method.body.cs"
             patterns: [
               {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -140,10 +140,12 @@ repository:
             name: "keyword.other.var.cs"
       }
       {
-        match: "^\\s*\\b(?!var|return|yield|throw)([\\w<>*?\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
+      }
+      {
+        match: "^\\s*\\b(?!var|return|yield|throw)([\\w+<>*?,\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
         captures:
           "1":
-            name: "storage.type.variable.cs"
+            name: "storage.type.variable.cs.test-red"
       }
     ]
   block:
@@ -416,9 +418,6 @@ repository:
         include: "#type-declaration"
       }
       {
-        include: "#variable"
-      }
-      {
         include: "#constants"
       }
       {
@@ -434,6 +433,9 @@ repository:
         # This should be types but we need to further refine other rules or
         # it will greedy consume variable names as type names.
         include: "#builtinTypes"
+      }
+      {
+        include: "#variable"
       }
     ]
   comments:
@@ -456,7 +458,7 @@ repository:
         captures:
           "0":
             name: "punctuation.definition.comment.cs"
-        end: "\\*/\\n?"
+        end: "\\*/"
         name: "comment.block.cs"
       }
       {
@@ -803,7 +805,7 @@ repository:
     begin: "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*(=)?"
     beginCaptures:
       "1":
-        name: "storage.type.modifier.cs"
+        name: "storage.modifier.cs"
       "2":
         patterns: [
           {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -169,7 +169,7 @@ repository:
   builtinTypes:
     patterns: [
       {
-        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)\\s*(\\?|\\*)?\\s*"
+        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)\\s*(\\?|\\*)?\\b"
         name: "storage.value.type.cs"
         captures:
           "2":
@@ -186,14 +186,30 @@ repository:
   typeName:
     patterns: [
       {
-        match: "([\\w\\.]+\\s*<(?:[\\w\\s,\\.`\\[\\]\\*]+|\\g<1>)+>(?:\\s*\\[\\s*\\])?)"
-        comment: "generic type"
+        begin: "\\b([a-zA-Z]+[\\w\\.]*)\\s*<"
+        end: ">"
         captures:
           "1":
-            name: "storage.type.cs"
+            name: "meta.generic.class.identifier.cs"
+        patterns: [
+          {
+            match: ","
+          }
+          {
+            match: "(\\w+)"
+            captures:
+              "1":
+                name: "meta.generic.type.specifier"
+                patterns: [
+                  {
+                    include: "#type"
+                  }
+                ]
+          }
+        ]
       }
       {
-        match: "\\b([a-zA-Z]+[\\w\\.]*\\b(?:\\s*\\[\\s*\\])?\\*?)"
+        match: "\\b([a-zA-Z]+[\\w\\.]*)\\s*(?:\\s*\\[\\s*\\])?\\*?\\b"
         comment: "non-generic type"
         captures:
           "1":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -90,7 +90,7 @@ repository:
   "field-declaration":
     patterns: [
       {
-        begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)(?:[\\w\\s,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
+        begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)(?:[\\w\\s?*,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
         end: "(?=;)"
         patterns: [
           {
@@ -349,9 +349,6 @@ repository:
         include: "#constants"
       }
       {
-        include: "#storage-modifiers"
-      }
-      {
         include: "#keywords"
       }
       {
@@ -359,12 +356,6 @@ repository:
       }
       {
         include: "#method-call"
-      }
-      {
-        include: "#builtinTypes"
-      }
-      {
-        include: "#documentation"
       }
     ]
   comments:

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -247,9 +247,6 @@ repository:
     name: "meta.class.cs"
     patterns: [
       {
-        include: "#storage-modifiers"
-      }
-      {
         include: "#comments"
       }
       {
@@ -543,7 +540,7 @@ repository:
         name: "keyword.operator.cs"
       }
       {
-        match: "\\b(event|delegate|fixed|add|remove|set|get|value|alias|global)\\b"
+        match: "\\b(event|delegate|fixed|add|remove|set|get|value|alias|global|extern)\\b"
         name: "keyword.other.cs"
       }
     ]
@@ -570,11 +567,8 @@ repository:
     end: "}|;|$"
     beginCaptures:
       "1":
-        patterns: [
-          {
-            include: "#storage-modifiers"
-          }
-        ]
+        match: "\\b(private|public|internal|protected|static|new|virtual|override)\\b"
+        name: "storage.modifier.cs"
       "2":
         patterns: [
           {
@@ -622,7 +616,8 @@ repository:
         name: "meta.method.cs"
         patterns: [
           {
-            include: "#storage-modifiers"
+            match: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\b"
+            name: "storage.modifier.cs"
           }
           {
             match: "\\bvoid\\b"
@@ -790,6 +785,3 @@ repository:
         name: "meta.preprocessor.cs"
       }
     ]
-  "storage-modifiers":
-    match: "\\b(event|delegate|internal|public|protected|private|static|const|new|sealed|abstract|virtual|override|extern|unsafe|readonly|volatile|implicit|explicit|operator|async|partial|alias)\\b"
-    name: "storage.modifier.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -169,14 +169,14 @@ repository:
   builtinTypes:
     patterns: [
       {
-        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)\\s*(\\?|\\*)?\\b"
+        match: "\\b(bool|byte|sbyte|char|decimal|double|enum|float|int|uint|long|ulong|short|ushort)\\s*(\\?|\\*)?\\s*\\b"
         name: "storage.value.type.cs"
         captures:
           "2":
             name: "punctuation.storage.type.modifier.cs"
       }
       {
-        match: "\\b(dynamic|object|string)\\s*(\\*)?\\b"
+        match: "\\b(dynamic|object|string)\\s*(\\*)?\\s*\\b"
         name: "storage.reference.type.cs"
         captures:
           "2":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -19,6 +19,9 @@ patterns: [
     include: "#comments"
   }
   {
+    include: "#enum-declaration"
+  }
+  {
     include: "#type-declaration"
   }
   {
@@ -148,6 +151,12 @@ repository:
         captures:
           "1":
             name: "keyword.other.var.cs"
+          "2":
+            patterns: [
+              {
+                include: "#code"
+              }
+            ]
       }
       {
         match: "(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*="
@@ -291,8 +300,81 @@ repository:
         include: "#generic-constraints"
       }
     ]
+  "enum-declaration":
+    begin: "(?=(?:public|private|protected|internal)?(.*)?(?:enum)\\s+\\w+)"
+    end: "}"
+    endCaptures:
+      "0":
+        name: "punctuation.section.enum.end.cs"
+    patterns: [
+      {
+        match: "\\b(public|private|protected|internal|static)\\b"
+        name: "storage.modifier.cs"
+      }
+      {
+        include: "#comments"
+      }
+      {
+        begin: "(enum)\\s+"
+        end: "(?={)"
+        name: "meta.enum.declaration.cs"
+        beginCaptures:
+          "1":
+            name: "keyword.enum.cs"
+        patterns: [
+          {
+            match: "\\b([a-zA-Z]+\\w*)\\b"
+            captures:
+              "1":
+                name: "meta.class.enum.identifier.cs"
+          }
+        ]
+      }
+      {
+        begin: "{"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.enum.begin.cs"
+        end: "(?=})"
+        patterns: [
+          {
+            include: "#comments"
+          }
+          {
+            match: ","
+          }
+          {
+            include: "#attribute"
+          }
+          {
+            begin: "\\b([a-zA-Z]+\\w*)\\b\\s*"
+            beginCaptures:
+              "1":
+                name: "entity.name.enum.cs"
+            end: "(?=,|})"
+            patterns: [
+              {
+                include: "#comments"
+              }
+              {
+                begin: "\\s*=\\s*"
+                end: "(?=,|})"
+                patterns: [
+                  {
+                    include: "#comments"
+                  }
+                  {
+                    include: "#constants"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
   "type-declaration":
-    begin: "(?=(?:public|private|protected|internal|static|partial)?(.*)?(?:class|struct|interface|enum)\\s+\\w+)"
+    begin: "(?=(?:public|private|protected|internal|static|partial)?(.*)?(?:class|struct|interface)\\s+\\w+)"
     end: "}"
     endCaptures:
       "0":
@@ -306,7 +388,7 @@ repository:
         include: "#comments"
       }
       {
-        begin: "(class|struct|interface|enum)\\s+"
+        begin: "(class|struct|interface)\\s+"
         end: "(?={|:|$|where)"
         name: "meta.type.declaration.cs"
         beginCaptures:
@@ -353,6 +435,9 @@ repository:
     patterns: [
       {
         include: "#attribute"
+      }
+      {
+        include: "#enum-declaration"
       }
       {
         include: "#type-declaration"
@@ -423,6 +508,9 @@ repository:
       }
       {
         include: "#comments"
+      }
+      {
+        include: "#enum-declaration"
       }
       {
         include: "#type-declaration"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -442,6 +442,9 @@ repository:
       {
         include: "#variable"
       }
+      {
+        include: "#builtinTypes"
+      }
     ]
   comments:
     patterns: [

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -604,10 +604,14 @@ repository:
             include: "#storage-modifiers"
           }
           {
+            match: "\\bvoid\\b"
+            name: "storage.type.cs"
+          }
+          {
             include: "#builtinTypes"
           }
           {
-            begin: "([\\w]+\\s*(?:<[\\w<>\\s,`?]*>)?)\\s*\\("
+            begin: "([\\w]+)\\s*(<[\\w<>\\s,`?]*>)?\\s*\\("
             beginCaptures:
               "1":
                 name: "entity.name.function.cs"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -88,7 +88,6 @@ repository:
     endCaptures:
       "0":
         name: "punctuation.section.namespace.end.cs"
-    name: "meta.namespace.cs"
     patterns: [
       {
         begin: "{"
@@ -96,7 +95,6 @@ repository:
           "0":
             name: "punctuation.section.namespace.begin.cs"
         end: "(?=})"
-        name: "meta.namespace.body.cs"
         patterns: [
           {
             include: "#using"
@@ -298,7 +296,6 @@ repository:
     endCaptures:
       "0":
         name: "punctuation.section.class.end.cs"
-    name: "meta.class.cs"
     patterns: [
       {
         match: "\\b(public|private|protected|internal|static|partial)\\b"
@@ -310,7 +307,6 @@ repository:
       {
         begin: "(class|struct|interface|enum)\\s+"
         end: "(?={|:|$|where)"
-        name: "meta.class.declaration.cs"
         beginCaptures:
           "1":
             name: "keyword.class.declaration.cs"
@@ -356,7 +352,6 @@ repository:
           "0":
             name: "punctuation.section.class.begin.cs"
         end: "(?=})"
-        name: "meta.class.body.cs"
         patterns: [
           {
             include: "#type-body"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -97,11 +97,7 @@ repository:
             match: "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
             captures:
               "1":
-                patterns: [
-                  {
-                    include: "#storage-modifiers"
-                  }
-                ]
+                name: "storage.modifier.cs"
               "2":
                 patterns: [
                   {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -754,6 +754,9 @@ repository:
             ]
           }
           {
+            include: "#generic-constraints"
+          }
+          {
             begin: ":\\s*(this|base)\\s*\\("
             beginCaptures:
               "1":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -679,9 +679,6 @@ repository:
               {
                 include: "#comments"
               }
-              {
-                include: "#builtinTypes"
-              }
             ]
           }
           {
@@ -770,7 +767,11 @@ repository:
       "1":
         name: "storage.type.modifier.cs"
       "2":
-        name: "storage.type.generic.cs"
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
       "3":
         name: "variable.parameter.function.cs"
       "4":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -30,7 +30,7 @@ patterns: [
 ]
 repository:
   using:
-    begin: "^\\s*(using)\\b\\s*"
+    begin: "\\b(using)\\b\\s*"
     captures:
       "1":
         name: "keyword.other.using.cs"
@@ -65,7 +65,7 @@ repository:
     ]
     end: "\\s*(?:$|;)"
   namespace:
-    begin: "^\\s*[^@]?((namespace)\\s+([\\w.]+))"
+    begin: "\\s*[^@]?((namespace)\\s+([\\w.]+))"
     beginCaptures:
       "1":
         name: "meta.namespace.identifier.cs"
@@ -104,9 +104,10 @@ repository:
       {
         begin: "(?=(?:(?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)(?:[\\w\\s?*,<>\\[\\]]+?)(?:[\\w]+)\\s*(?:;|=|=>))"
         end: "(?=;)"
+        name: "meta.field.declaration.cs"
         patterns: [
           {
-            match: "^\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
+            match: "\\s*((?:(?:private|public|volatile|internal|protected|static|readonly|const|event|extern)\\s*)*)\\s*(.+?)\\s*([\\w]+)\\s*(?=;|=)"
             captures:
               "1":
                 name: "storage.modifier.cs"
@@ -134,7 +135,7 @@ repository:
   variable:
     patterns: [
       {
-        match: "^\\s*\\b(var)\\s+(.*?)(?=(=|;))"
+        match: "\\s*\\b(var)\\s+(.*?)(?=(=|;))"
         captures:
           "1":
             name: "keyword.other.var.cs"
@@ -150,7 +151,7 @@ repository:
             ]
       }
       {
-        match: "^\\s*\\b(?!var|return|yield|throw)([\\w+<>*?,\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
+        match: "\\s*\\b(?!var|return|yield|throw)([\\w+<>*?,\\[\\]]+)\\s+([\\w]+)\\s*(?=(=(?!=)|;))"
         captures:
           "1":
             name: "storage.type.variable.cs"
@@ -281,7 +282,7 @@ repository:
       }
     ]
   "type-declaration":
-    begin: "(?=(?:public|private|protected|internal|static|partial)?[^@](.*)?(?:class|struct|interface|enum)\\s+\\w+)"
+    begin: "(?=(?:public|private|protected|internal|static|partial)?(.*)?(?:class|struct|interface|enum)\\s+\\w+)"
     end: "}"
     endCaptures:
       "0":
@@ -441,11 +442,6 @@ repository:
       }
       {
         include: "#method-call"
-      }
-      {
-        # This should be types but we need to further refine other rules or
-        # it will greedy consume variable names as type names.
-        include: "#builtinTypes"
       }
       {
         include: "#variable"
@@ -663,7 +659,7 @@ repository:
       }
     ]
   "property-declaration":
-    begin: "^\\s*(?!.*\\b(?:class|interface|struct)\\b)((?:\\w+\\s+)*?)(?!(?:private|public|internal|protected|static|new|virtual|override))(\\w.+?)\\s+(\\w+)\\s*(?={|$)"
+    begin: "\\s*(?!.*\\b(?:class|interface|struct)\\b)((?:\\w+\\s+)*?)(?!(?:private|public|internal|protected|static|new|virtual|override))(\\w.+?)\\s+(\\w+)\\s*(?={|$)"
     end: "}|;|$"
     beginCaptures:
       "1":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -141,7 +141,7 @@ repository:
             name: "keyword.other.var.cs"
       }
       {
-        match: "(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)"
+        match: "(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*="
         captures:
           "1":
             patterns: [
@@ -824,6 +824,7 @@ repository:
       }
     ]
   parameters:
+    name: "meta.parameters.cs"
     begin: "\\b(ref|params|out)?\\s*\\b(\\w+(?:\\s*<.*?>)?(?:\\s*\\*)*(?:\\s*\\?)?(?:\\s*\\[.*?\\])?)\\s+(@?\\w+)\\s*(=)?"
     beginCaptures:
       "1":

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -30,20 +30,23 @@ patterns: [
 ]
 repository:
   using:
-    begin: "\\b(using)\\b\\s*"
-    captures:
+    begin: "\\s*\\b(using)\\b"
+    beginCaptures:
       "1":
         name: "keyword.other.using.cs"
+    end: "\\s*(?:$|;)"
     patterns: [
-      {
-        match: "\\s*static\\b"
-        name: "keyword.other.static.cs"
-      }
       {
         include: "#comments"
       }
       {
-        begin: "(\\w+)\\s*=\\s*"
+        match: "\\s*\\b(static)\\b"
+        captures:
+          1:
+            name: "keyword.other.static.cs"
+      }
+      {
+        begin: "(\\w+)(?=.*\\=)"
         beginCaptures:
           "1":
             name: "entity.name.alias.namespace.cs"
@@ -52,18 +55,26 @@ repository:
             include: "#comments"
           }
           {
-            match: "[\\w.]+"
-            name: "entity.name.type.namespace.cs"
+            begin: "\\s*\\=(?=[\\w\\s/])"
+            patterns: [
+              {
+                include: "#comments"
+              }
+              {
+                match: "[\\w.]+"
+                name: "entity.name.type.namespace.cs"
+              }
+            ]
+            end: "(?=;)"
           }
         ]
-        end: "\\s+"
+        end: ";"
       }
       {
         match: "[\\w.]+"
         name: "entity.name.type.namespace.cs"
       }
     ]
-    end: "\\s*(?:$|;)"
   namespace:
     begin: "\\s*[^@]?((namespace)\\s+([\\w.]+))"
     beginCaptures:

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -366,11 +366,25 @@ repository:
       {
         include: "#castTypeOperator"
       }
+      {
+        include: "#functionTypeOperator"
+      }
     ]
   castTypeOperator:
     match: "\\((\\w+[?*,<>\\[\\]]*)\\)"
     captures:
       "1":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+  functionTypeOperator:
+    match: "\\b(typeof|sizeof)\\s*\\((\\w+[?*,<>\\[\\]]*)\\)"
+    captures:
+      "1":
+        name: "keyword.operator.cs"
+      "2":
         patterns: [
           {
             include: "#type"
@@ -607,7 +621,7 @@ repository:
         name: "keyword.linq.cs"
       }
       {
-        match: "\\b(new|is|as|using|checked|unchecked|typeof|sizeof|override|readonly|stackalloc|nameof)\\b"
+        match: "\\b(using|checked|unchecked|override|readonly|stackalloc|nameof)\\b"
         name: "keyword.operator.cs"
       }
       {

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -649,6 +649,24 @@ repository:
             beginCaptures:
               "1":
                 name: "entity.name.function.cs"
+              "2":
+                name: "meta.generic.method.identifier"
+                patterns: [
+                  {
+                    match: ","
+                  }
+                  {
+                    match: "(\\w+)"
+                    captures:
+                      "1":
+                        name: "meta.generic.type.specifier"
+                        patterns: [
+                          {
+                            include: "#type"
+                          }
+                        ]
+                  }
+                ]
             end: "\\)"
             name: "meta.method.identifier.cs"
             patterns: [

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -639,6 +639,7 @@ repository:
           "1":
             name: "storage.modifier.cs"
           "2":
+            name: "meta.method.return-type.cs"
             patterns: [
               {
                 include: "#returnType"
@@ -665,21 +666,23 @@ repository:
         ]
       }
       {
-        begin: "(?<!=|=\\s)(?!new)(?!.*(=|\\/\\/|\\/\\*).*\\()(?=[\\w<].*\\s+.+\\()"
-        end: "(})|(?=;)"
+        begin: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\s+(void|[\\w<>.?*\\[\\],]+)\\s+(?=.*{\\s*)"
+        beginCaptures:
+          "1":
+            name: "storage.modifier.cs"
+          "2":
+            name: "meta.method.return-type.cs"
+            patterns: [
+              {
+                include: "#returnType"
+              }
+            ]
+        end: "}"
         endCaptures:
           "1":
             name: "punctuation.section.method.end.cs"
         name: "meta.method.cs"
         patterns: [
-          {
-            match: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\b"
-            name: "storage.modifier.cs"
-          }
-          {
-            name: "meta.method.return-type.cs"
-            include: "#returnType"
-          }
           {
             begin: "([\\w]+)\\s*(<[\\w<>\\s,`?]*>)?\\s*\\("
             beginCaptures:

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -235,13 +235,18 @@ repository:
       }
     ]
   "generic-constraints":
-    begin: "(where)\\s+(\\w+)\\s*:"
+    begin: "(where)\\s+(\\w+([?*])?)\\s*:"
     end: "(?=where|{|$)"
     beginCaptures:
       "1":
         name: "keyword.other.cs"
       "2":
-        name: "storage.type.cs"
+        name: "meta.generic.type.specifier"
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
     patterns: [
       {
         match: "\\b(class|struct)\\b"

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -639,43 +639,13 @@ repository:
         ]
       }
       {
-        begin: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\s+(void|[\\w<>.?*\\[\\],]+)\\s+(?=.*=>\\s*)"
-        beginCaptures:
-          "1":
-            name: "storage.modifier.cs"
-          "2":
-            name: "meta.method.return-type.cs"
-            patterns: [
-              {
-                include: "#returnType"
-              }
-            ]
-        end: ";"
-        patterns: [
-          {
-            include: "#parameters"
-          }
-          {
-            begin: "=>"
-            beginCaptures:
-              "0":
-                name: "punctuation.section.method.begin.cs"
-            end: "(?=;)"
-            name: "meta.method.body.cs"
-            patterns: [
-              {
-                include: "#code"
-              }
-            ]
-          }
-        ]
+        match: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\b"
+        name: "storage.modifier.cs"
       }
       {
-        begin: "\\b(internal|public|protected|private|static|new|abstract|virtual|override|implicit|explicit|operator|async|partial)\\s+(void|[\\w<>.?*\\[\\],]+)\\s+(?=.*{\\s*)"
+        begin: "(void|[\\w<>.?*\\[\\],]+)\\s*(?=.*)"
         beginCaptures:
           "1":
-            name: "storage.modifier.cs"
-          "2":
             name: "meta.method.return-type.cs"
             patterns: [
               {
@@ -722,16 +692,6 @@ repository:
               }
               {
                 include: "#comments"
-              }
-            ]
-          }
-          {
-            begin: "(?=\\w.*\\s+[\\w.]+\\s*\\()"
-            end: "(?=[\\w.]+\\s*\\()"
-            name: "meta.method.return-type.cs"
-            patterns: [
-              {
-                include: "#returnType"
               }
             ]
           }

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -260,6 +260,7 @@ repository:
       }
     ]
   "generic-constraints":
+    name: "meta.generic.constraints.cs"
     begin: "(where)\\s+(\\w+([?*])?)\\s*:"
     end: "(?=where|{|$)"
     beginCaptures:
@@ -307,24 +308,13 @@ repository:
       {
         begin: "(class|struct|interface|enum)\\s+"
         end: "(?={|:|$|where)"
+        name: "meta.type.declaration.cs"
         beginCaptures:
           "1":
-            name: "keyword.class.declaration.cs"
+            name: "keyword.class.cs"
         patterns: [
           {
             include: "#typeName"
-          }
-          {
-            begin: "[<]\\s*"
-            end: "\\s*[>]"
-            patterns: [
-              {
-                include: "#typeName"
-              }
-              {
-                match: ","
-              }
-            ]
           }
         ]
       }

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -259,6 +259,7 @@ repository:
       {
         begin: "(class|struct|interface|enum)\\s+"
         end: "(?={|:|$|where)"
+        name: "meta.class.declaration.cs"
         beginCaptures:
           "1":
             name: "keyword.class.declaration.cs"
@@ -269,7 +270,6 @@ repository:
           {
             begin: "[<]\\s*"
             end: "\\s*[>]"
-            name: "punctuation.type.specifiers.cs"
             patterns: [
               {
                 include: "#typeName"

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -36,18 +36,17 @@ describe "Language C# package", ->
       expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs']
 
     fit "tokenizes method definitions correctly", ->
-      {tokens} = grammar.tokenizeLine("void func()")
+      {tokens} = grammar.tokenizeLine("void func() { }")
+      expect(tokens[6]).toEqual value: 'void', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'storage.type.cs']
+      expect(tokens[8]).toEqual value: 'func', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'entity.name.function.declaration.cs']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'punctuation.definition.method-parameters.begin.cs']
+
+      {tokens} = grammar.tokenizeLine("dictionary<int, string> func() { }")
       console.log(tokens)
-
-      expect(tokens[0][1]).toEqual value: 'void ', scopes: ['source.cs']
-      expect(tokens[0][2]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[0][3]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
-
-      {tokens} = grammar.tokenizeLine("dictionary<int, string> func()")
       expect(tokens[5]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
       expect(tokens[6]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
 
-      {tokens} = grammar.tokenizeLine("void func(test = default_value)")
+      {tokens} = grammar.tokenizeLine("void func(test = default_value) { }")
       expect(tokens[0]).toEqual value: 'void ', scopes: ['source.cs']
       expect(tokens[1]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
       expect(tokens[2]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -22,39 +22,40 @@ describe "Language C# package", ->
       }
       """
 
-      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
-      expect(tokens[1][5]).toEqual value: '//', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
-      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.field.declaration.cs', 'storage.value.type.cs']
+      expect(tokens[1][5]).toEqual value: '//', scopes: ['source.cs', 'comment.line.double-slash.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'comment.line.double-slash.cs']
 
       tokens = grammar.tokenizeLines """
       struct hi {
         byte q; /*(*/
       }
       """
-      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
-      expect(tokens[1][5]).toEqual value: '/*', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs', 'punctuation.definition.comment.cs']
-      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.field.declaration.cs', 'storage.value.type.cs']
+      expect(tokens[1][5]).toEqual value: '/*', scopes: ['source.cs', 'comment.block.cs', 'punctuation.definition.comment.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'comment.block.cs']
 
-    fit "tokenizes method definitions correctly", ->
+    it "tokenizes method definitions correctly", ->
       {tokens} = grammar.tokenizeLine("void func() { }")
-      expect(tokens[6]).toEqual value: 'void', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'storage.type.cs']
-      expect(tokens[8]).toEqual value: 'func', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'entity.name.function.declaration.cs']
-      expect(tokens[9]).toEqual value: '(', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'punctuation.definition.method-parameters.begin.cs']
+      expect(tokens[0]).toEqual value: 'void', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'storage.type.cs']
+      expect(tokens[2]).toEqual value: 'func', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'entity.name.function.declaration.cs']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'punctuation.definition.method-parameters.begin.cs']
 
       {tokens} = grammar.tokenizeLine("dictionary<int, string> func() { }")
-      console.log(tokens)
-      expect(tokens[5]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[6]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      expect(tokens[0]).toEqual value: 'dictionary', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'meta.generic.class.identifier.cs']
+      expect(tokens[2]).toEqual value: 'int', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'meta.generic.type.specifier.cs', 'storage.value.type.cs']
+      expect(tokens[6]).toEqual value: 'func', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'entity.name.function.declaration.cs']
+      expect(tokens[7]).toEqual value: '(', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'punctuation.definition.method-parameters.begin.cs']
 
       {tokens} = grammar.tokenizeLine("void func(test = default_value) { }")
-      expect(tokens[0]).toEqual value: 'void ', scopes: ['source.cs']
-      expect(tokens[1]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[2]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      expect(tokens[0]).toEqual value: 'void', scopes: ['source.cs', 'meta.method.cs', 'meta.method.return-type.cs', 'storage.type.cs']
+      expect(tokens[2]).toEqual value: 'func', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'entity.name.function.declaration.cs']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.cs', 'meta.method.cs', 'meta.method.identifier.cs', 'punctuation.definition.method-parameters.begin.cs']
 
     it "tokenizes method calls", ->
-      {tokens} = grammar.tokenizeLine("a = func(1)")
-      expect(tokens[1]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[2]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      {tokens} = grammar.tokenizeLine("var a = func(1)")
+      expect(tokens[4]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
 
       {tokens} = grammar.tokenizeLine("func()")
       expect(tokens[0]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
@@ -75,13 +76,13 @@ describe "Language C# package", ->
         })
       """
 
-      expect(tokens[1][5]).toEqual value: 'C', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
-      expect(tokens[1][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
-      expect(tokens[1][8]).toEqual value: '1.1 10', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs']
-      expect(tokens[1][9]).toEqual value: '\\n', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'constant.character.escape.cs']
-      expect(tokens[1][10]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
-      expect(tokens[1][11]).toEqual value: ')', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.end.cs']
+      expect(tokens[1][5]).toEqual value: 'C', scopes: ['source.cs', 'meta.field.declaration.cs', 'meta.method-call.cs', 'meta.method.cs']
+      expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      expect(tokens[1][7]).toEqual value: '"', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
+      expect(tokens[1][8]).toEqual value: '1.1 10', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'string.quoted.double.cs']
+      expect(tokens[1][9]).toEqual value: '\\n', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'constant.character.escape.cs']
+      expect(tokens[1][10]).toEqual value: '"', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
+      expect(tokens[1][11]).toEqual value: ')', scopes: ['source.cs',  'meta.field.declaration.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.end.cs']
 
     it "tokenizes strings in classes", ->
       tokens = grammar.tokenizeLines """
@@ -91,25 +92,10 @@ describe "Language C# package", ->
         }
       """
 
-      expect(tokens[2][5]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
-      expect(tokens[2][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs']
-      expect(tokens[2][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
-      expect(tokens[2][8]).toEqual value: ';', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs']
-
-      tokens = grammar.tokenizeLines """
-        class a
-        {
-          b([c(d = "Command e")] string f)
-          {
-          }
-        }
-      """
-
-      expect(tokens[2][7]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
-      expect(tokens[2][8]).toEqual value: 'Command e', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method-call.cs', 'string.quoted.double.cs']
-      expect(tokens[2][9]).toEqual value: '"', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'meta.method-call.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
-      expect(tokens[2][12]).toEqual value: 'string ', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs', 'storage.reference.type.cs']
-      expect(tokens[2][13]).toEqual value: 'f', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'meta.method-call.cs']
+      expect(tokens[2][5]).toEqual value: '"', scopes: ['source.cs', 'meta.field.declaration.cs', 'string.quoted.double.cs', 'punctuation.definition.string.begin.cs']
+      expect(tokens[2][6]).toEqual value: '(', scopes: ['source.cs', 'meta.field.declaration.cs', 'string.quoted.double.cs']
+      expect(tokens[2][7]).toEqual value: '"', scopes: ['source.cs', 'meta.field.declaration.cs', 'string.quoted.double.cs', 'punctuation.definition.string.end.cs']
+      expect(tokens[2][8]).toEqual value: ';', scopes: ['source.cs']
 
     describe "Preprocessor directives", ->
       directives = [ '#if DEBUG', '#else', '#elif RELEASE', '#endif',

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -22,7 +22,7 @@ describe "Language C# package", ->
       }
       """
 
-      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.type.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
       expect(tokens[1][5]).toEqual value: '//', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
       expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.line.double-slash.cs']
 
@@ -31,15 +31,17 @@ describe "Language C# package", ->
         byte q; /*(*/
       }
       """
-      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.type.cs']
+      expect(tokens[1][1]).toEqual value: 'byte', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'storage.value.type.cs']
       expect(tokens[1][5]).toEqual value: '/*', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs', 'punctuation.definition.comment.cs']
       expect(tokens[1][6]).toEqual value: '(', scopes: ['source.cs', 'meta.class.cs', 'meta.class.body.cs', 'comment.block.cs']
 
-    it "tokenizes method definitions correctly", ->
+    fit "tokenizes method definitions correctly", ->
       {tokens} = grammar.tokenizeLine("void func()")
-      expect(tokens[0]).toEqual value: 'void ', scopes: ['source.cs']
-      expect(tokens[1]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
-      expect(tokens[2]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
+      console.log(tokens)
+
+      expect(tokens[0][1]).toEqual value: 'void ', scopes: ['source.cs']
+      expect(tokens[0][2]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']
+      expect(tokens[0][3]).toEqual value: '(', scopes: ['source.cs', 'meta.method-call.cs', 'punctuation.definition.method-parameters.begin.cs']
 
       {tokens} = grammar.tokenizeLine("dictionary<int, string> func()")
       expect(tokens[5]).toEqual value: 'func', scopes: ['source.cs', 'meta.method-call.cs', 'meta.method.cs']


### PR DESCRIPTION
Ideally this would have been smaller changes but the grammar had many many issues.

This adds support to or fixes highlighting for:

- Generic methods
- Generic types
- Type constraints
- Extern fields
- Nullable/pointer built-in types
- Lambda method syntax (C# 6)
- Method bodies
- Type recognition on cast/as/in/sizeof/typeof
- Interface names (convention based on I[A-Z] in absence of type engine)
- Improvements in newline handling (allowing more, not requiring any)

Ideally would have more work done on newlines and comments being allowed everywhere but that's an ongoing issue.

Here's what code can now look like using a VS-style theme I put together;

![image](https://cloud.githubusercontent.com/assets/118951/21485768/1afbe0c0-cb5d-11e6-9a2b-211ca9965fdf.png)

Still remaining before merge:

1. Fix specs
2. Get basic types parsing in method bodies