### PR TITLE
Highlight 'out' and 'ref' in method call

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -916,6 +916,10 @@ repository:
         name: "punctuation.definition.separator.parameter.cs"
       }
       {
+          match: "\\b(ref|out)\\b"
+          name: "storage.modifier.cs"
+      }
+      {
         include: "#code"
       }
     ]


### PR DESCRIPTION
`out` and `ref` are already highlighted in method definition, but highlight in method call was missing.


### Alternate Designs

`ref` and `out` could be keywords

