### PR TITLE
Don't optionally match trailing newlines in comments

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -539,7 +539,7 @@ repository:
         captures:
           "0":
             name: "punctuation.definition.comment.cs"
-        end: "$\\n?"
+        end: "$"
         name: "comment.block.documentation.cs"
         patterns: [
           {
@@ -560,7 +560,7 @@ repository:
         captures:
           "1":
             name: "punctuation.definition.comment.cs"
-        end: "$\\n?"
+        end: "$"
         name: "comment.line.double-slash.cs"
       }
     ]

--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -536,7 +536,7 @@ repository:
     patterns: [
       {
         begin: "///"
-        captures:
+        beginCaptures:
           "0":
             name: "punctuation.definition.comment.cs"
         end: "$"
@@ -549,15 +549,18 @@ repository:
       }
       {
         begin: "/\\*"
-        captures:
+        beginCaptures:
           "0":
             name: "punctuation.definition.comment.cs"
         end: "\\*/"
+        endCaptures:
+          "0":
+            name: "punctuation.definition.comment.cs"
         name: "comment.block.cs"
       }
       {
         begin: "//"
-        captures:
+        beginCaptures:
           "1":
             name: "punctuation.definition.comment.cs"
         end: "$"

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -166,10 +166,10 @@ describe "Language C# package", ->
             else
               expect(token[0].value).toBe(directive)
 
-            expect(token[token.length - 3].value).toBe('//')
-            expect(token[token.length - 3].scopes).toContain('comment.line.double-slash.cs')
-            expect(token[token.length - 2].value).toBe(' A line comment')
+            expect(token[token.length - 2].value).toBe('//')
             expect(token[token.length - 2].scopes).toContain('comment.line.double-slash.cs')
+            expect(token[token.length - 1].value).toBe(' A line comment')
+            expect(token[token.length - 1].scopes).toContain('comment.line.double-slash.cs')
 
   describe "C# Script grammar", ->
     it "parses the grammar", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I don't believe it's doing anything useful?

### Alternate Designs

Keep the newline match and edit the tests instead.

### Benefits

language-csharp tests will pass against first-mate@7.0.8+.

### Possible Drawbacks

None, unless the newline match is doing something important.

### Applicable Issues

atom/first-mate#100