### PR TITLE
Add "async" as a keyword

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -712,7 +712,7 @@ repository:
   keywords:
     patterns: [
       {
-        match: "\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|when)\\b"
+        match: "\\b(if|else|while|for|foreach|in|do|return|continue|break|switch|case|default|goto|throw|try|catch|finally|lock|yield|await|async|when)\\b"
         name: "keyword.control.cs"
       }
       {


### PR DESCRIPTION
While C# supports async lambdas, the word **async** should not only be treated as a modifier but also as a keyword. Fix for https://github.com/atom/language-csharp/issues/105 