### PR TITLE
Add method call highlighting

### DIFF
--- a/grammars/c#.cson
+++ b/grammars/c#.cson
@@ -905,7 +905,7 @@ repository:
     begin: "([\\w$]+)\\s*(\\()"
     beginCaptures:
       "1":
-        name: "meta.method.cs"
+        name: "entity.name.function.cs"
       "2":
         name: "punctuation.definition.method-parameters.begin.cs"
     end: "\\)"


### PR DESCRIPTION
Added method call highlighting like in Java Atom plugin https://github.com/atom/language-java/blob/master/grammars/java.cson#L827 

Now C#'s method chains look rather pretty! How it was before (ugly):

![image](https://user-images.githubusercontent.com/6759207/35586253-6a133944-060b-11e8-8a28-2e7b38dbe13a.png)

How it is now (pretty):

![image](https://user-images.githubusercontent.com/6759207/35586265-73210304-060b-11e8-8f55-c434d1610a1d.png)
