### PR TITLE
Improve method parameters highlighting

### DIFF
--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -919,11 +919,11 @@ repository:
           }
         ]
       "6":
-        name: "entity.name.variable.field.cs"
+        name: "variable.field.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "entity.name.variable.field.cs"
+        name: "variable.field.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -1829,7 +1829,7 @@ repository:
                   }
                 ]
               "7":
-                name: "entity.name.variable.local.cs"
+                name: "variable.local.cs"
               "8":
                 name: "keyword.control.loop.in.cs"
           }
@@ -1947,7 +1947,7 @@ repository:
                   }
                 ]
               "6":
-                name: "entity.name.variable.local.cs"
+                name: "variable.local.cs"
           }
         ]
       }
@@ -2108,11 +2108,11 @@ repository:
           }
         ]
       "8":
-        name: "entity.name.variable.local.cs"
+        name: "variable.local.cs"
     end: "(?=;|\\))"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.local.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2158,11 +2158,11 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.local.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.local.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2314,7 +2314,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.local.cs"
   "declaration-expression-tuple":
     match: '''
       (?x) # e.g. int x OR var x

--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -3145,7 +3145,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.cs"
   "argument-list":
     begin: "\\("
     beginCaptures:
@@ -3190,7 +3190,7 @@ repository:
     begin: "([_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     beginCaptures:
       "1":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.cs"
       "2":
         name: "punctuation.separator.colon.cs"
     end: "(?=(,|\\)|\\]))"
@@ -3483,7 +3483,7 @@ repository:
           "1":
             name: "storage.modifier.cs"
           "2":
-            name: "entity.name.variable.parameter.cs"
+            name: "variable.parameter.cs"
           "3":
             name: "keyword.operator.arrow.cs"
         end: "(?=\\)|;|}|,)"
@@ -3611,7 +3611,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.cs"
   type:
     name: "meta.type.cs"
     patterns: [


### PR DESCRIPTION
Implements better parameters highlighting for methods, lambdas, constructors, delegates. 
Uses [language-java](https://github.com/atom/language-java/blob/master/grammars/java.cson#L504) approach. See demo on [GitHub Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=http%3A%2F%2F149.154.70.247%2Fcsharp.cson.txt&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fworldbeater%2FmyFeed%2Fblob%2Fmaster%2FmyFeed%2FServices%2FBackgroundService.cs&code=).
![image](https://user-images.githubusercontent.com/6759207/38958832-13f8ec68-4367-11e8-99ac-01dac86d7278.png)
BTW still not sure about colors. Maybe black color will be more pretty, maybe light orange is just fine, don't know. So came up with using one that Java highlighter does.