### PR TITLE
Black method parameters highlighting

### DIFF
--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -919,11 +919,11 @@ repository:
           }
         ]
       "6":
-        name: "entity.name.variable.field.cs"
+        name: "variable.other.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "entity.name.variable.field.cs"
+        name: "variable.other.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -1829,7 +1829,7 @@ repository:
                   }
                 ]
               "7":
-                name: "entity.name.variable.local.cs"
+                name: "variable.other.cs"
               "8":
                 name: "keyword.control.loop.in.cs"
           }
@@ -1947,7 +1947,7 @@ repository:
                   }
                 ]
               "6":
-                name: "entity.name.variable.local.cs"
+                name: "variable.other.cs"
           }
         ]
       }
@@ -2108,11 +2108,11 @@ repository:
           }
         ]
       "8":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
     end: "(?=;|\\))"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2158,11 +2158,11 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
         match: "[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2314,7 +2314,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
   "declaration-expression-tuple":
     match: '''
       (?x) # e.g. int x OR var x
@@ -3145,7 +3145,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
   "argument-list":
     begin: "\\("
     beginCaptures:
@@ -3190,7 +3190,7 @@ repository:
     begin: "([_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     beginCaptures:
       "1":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
       "2":
         name: "punctuation.separator.colon.cs"
     end: "(?=(,|\\)|\\]))"
@@ -3483,7 +3483,7 @@ repository:
           "1":
             name: "storage.modifier.cs"
           "2":
-            name: "entity.name.variable.parameter.cs"
+            name: "variable.parameter.function.cs"
           "3":
             name: "keyword.operator.arrow.cs"
         end: "(?=\\)|;|}|,)"
@@ -3611,7 +3611,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
   type:
     name: "meta.type.cs"
     patterns: [


### PR DESCRIPTION
Made some color tweaks, so now C# syntax highlighter uses black color for lambda parameters, function parameters, and private fields. Color keys are taken from [scope-names.json](https://gist.github.com/Alhadis/f742feb8f5c871b449dff39bb3dd6f5d#file-scope-names-json-L76) that GitHub [uses](https://github.com/primer). More info on this can be found [here](https://github.com/github/linguist/issues/4104#issuecomment-382692321).

Please, take a look at [how it works now](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=http%3A%2F%2F149.154.70.247%2Fcsharp.black.cson.txt&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fworldbeater%2FmyFeed%2Fblob%2Fmaster%2FmyFeed%2FServices%2FBackgroundService.cs&code=):

![image](https://user-images.githubusercontent.com/6759207/38993827-59782264-43ed-11e8-8e14-28688c16581a.png)

Not yet tested this in Atom.
