### PR TITLE
Use black color for properties

### DIFF
--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -983,7 +983,7 @@ repository:
           }
         ]
       "8":
-        name: "entity.name.variable.property.cs"
+        name: "variable.other.cs"
     end: "(?<=\\})|(?=;)"
     patterns: [
       {


### PR DESCRIPTION
Now uses black color for properties also. This is [how it was before](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=https%3A%2F%2Fgithub.com%2Fatom%2Flanguage-csharp%2Fblob%2Fmaster%2Fgrammars%2Fcsharp.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fworldbeater%2FmyFeed%2Fmaster%2FmyFeed%2FViewModels%2FFeedViewModel.cs&code=) (inconsistent):

![image](https://user-images.githubusercontent.com/6759207/39020869-05863fd4-4437-11e8-85a3-fa592b91089a.png)

This is [how it is after](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=cson&grammar_url=http%3A%2F%2F149.154.70.247%2Fcsharp.prop.cson.txt&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fraw.githubusercontent.com%2Fworldbeater%2FmyFeed%2Fmaster%2FmyFeed%2FViewModels%2FFeedViewModel.cs) (uses black like fields, variables, params, etc.):

![image](https://user-images.githubusercontent.com/6759207/39020525-e758e80a-4435-11e8-8ad9-9e4706baee9d.png)

This is what I've [forgotten to implement here](https://github.com/atom/language-csharp/pull/118).
