### PR TITLE
Update csharp.cson, fix converter paths

### DIFF
--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -109,13 +109,13 @@ repository:
         include: "#type-declarations"
       }
       {
+        include: "#property-declaration"
+      }
+      {
         include: "#field-declaration"
       }
       {
         include: "#event-declaration"
-      }
-      {
-        include: "#property-declaration"
       }
       {
         include: "#indexer-declaration"
@@ -154,10 +154,10 @@ repository:
         include: "#comment"
       }
       {
-        include: "#event-declaration"
+        include: "#property-declaration"
       }
       {
-        include: "#property-declaration"
+        include: "#event-declaration"
       }
       {
         include: "#indexer-declaration"
@@ -335,7 +335,7 @@ repository:
       }
     ]
   "extern-alias-directive":
-    begin: "\\s*(extern)\\b\\s*(alias)\\b\\s*([_[:alpha:]][_[:alnum:]]*)"
+    begin: "\\s*(extern)\\b\\s*(alias)\\b\\s*(@?[_[:alpha:]][_[:alnum:]]*)"
     beginCaptures:
       "1":
         name: "keyword.other.extern.cs"
@@ -361,7 +361,7 @@ repository:
         ]
       }
       {
-        begin: "\\b(using)\\s+(?=([_[:alpha:]][_[:alnum:]]*)\\s*=)"
+        begin: "\\b(using)\\s+(?=(@?[_[:alpha:]][_[:alnum:]]*)\\s*=)"
         beginCaptures:
           "1":
             name: "keyword.other.using.cs"
@@ -392,7 +392,7 @@ repository:
           }
           {
             name: "entity.name.type.namespace.cs"
-            match: "[_[:alpha:]][_[:alnum:]]*"
+            match: "@?[_[:alpha:]][_[:alnum:]]*"
           }
           {
             include: "#operator-assignment"
@@ -454,7 +454,7 @@ repository:
       }
     ]
   "attribute-named-argument":
-    begin: "([_[:alpha:]][_[:alnum:]]*)\\s*(?==)"
+    begin: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(?==)"
     beginCaptures:
       "1":
         name: "entity.name.variable.property.cs"
@@ -479,7 +479,7 @@ repository:
       }
       {
         name: "entity.name.type.namespace.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
         include: "#punctuation-accessor"
@@ -508,7 +508,7 @@ repository:
     ]
   "storage-modifier":
     name: "storage.modifier.cs"
-    match: "(?<!\\.)\\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe)\\b"
+    match: "(?<!\\.)\\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref)\\b"
   "class-declaration":
     begin: "(?=\\bclass\\b)"
     end: "(?<=\\})"
@@ -517,7 +517,7 @@ repository:
         begin: '''
           (?x)
           \\b(class)\\b\\s+
-          ([_[:alpha:]][_[:alnum:]]*)\\s*
+          (@?[_[:alpha:]][_[:alnum:]]*)\\s*
         '''
         beginCaptures:
           "1":
@@ -568,9 +568,9 @@ repository:
       (?:\\b(delegate)\\b)\\s+
       (?<typename>
         (?:
-          (?:ref\\s+)?   # ref return
+          (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -578,7 +578,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -628,7 +627,7 @@ repository:
             include: "#comment"
           }
           {
-            match: "(enum)\\s+([_[:alpha:]][_[:alnum:]]*)"
+            match: "(enum)\\s+(@?[_[:alpha:]][_[:alnum:]]*)"
             captures:
               "1":
                 name: "keyword.other.enum.cs"
@@ -672,7 +671,7 @@ repository:
             include: "#punctuation-comma"
           }
           {
-            begin: "[_[:alpha:]][_[:alnum:]]*"
+            begin: "@?[_[:alpha:]][_[:alnum:]]*"
             beginCaptures:
               "0":
                 name: "entity.name.variable.enum-member.cs"
@@ -703,7 +702,7 @@ repository:
         begin: '''
           (?x)
           (interface)\\b\\s+
-          ([_[:alpha:]][_[:alnum:]]*)
+          (@?[_[:alpha:]][_[:alnum:]]*)
         '''
         beginCaptures:
           "1":
@@ -756,7 +755,7 @@ repository:
         begin: '''
           (?x)
           (struct)\\b\\s+
-          ([_[:alpha:]][_[:alnum:]]*)
+          (@?[_[:alpha:]][_[:alnum:]]*)
         '''
         beginCaptures:
           "1":
@@ -818,7 +817,7 @@ repository:
             name: "storage.modifier.cs"
       }
       {
-        match: "\\b([_[:alpha:]][_[:alnum:]]*)\\b"
+        match: "(@?[_[:alpha:]][_[:alnum:]]*)\\b"
         captures:
           "1":
             name: "entity.name.type.type-parameter.cs"
@@ -851,7 +850,7 @@ repository:
       }
     ]
   "generic-constraints":
-    begin: "(where)\\s+([_[:alpha:]][_[:alnum:]]*)\\s*(:)"
+    begin: "(where)\\s+(@?[_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     beginCaptures:
       "1":
         name: "keyword.other.where.cs"
@@ -895,7 +894,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -903,7 +902,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -924,7 +922,7 @@ repository:
     patterns: [
       {
         name: "variable.other.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
         include: "#punctuation-comma"
@@ -942,13 +940,17 @@ repository:
   "property-declaration":
     begin: '''
       (?x)
-      (?!.*\\b(?:class|interface|struct|enum|event)\\b)\\s*
+      
+      # The negative lookahead below ensures that we don't match nested types
+      # or other declarations as properties.
+      (?![[:word:][:space:]]*\\b(?:class|interface|struct|enum|event)\\b)
+      
       (?<returntype>
         (?<typename>
           (?:
-            (?:ref\\s+)?   # ref return
+            (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -956,7 +958,6 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1008,9 +1009,9 @@ repository:
       (?<returntype>
         (?<typename>
           (?:
-            (?:ref\\s+)?   # ref return
+            (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1018,7 +1019,6 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1072,7 +1072,7 @@ repository:
         (?<typename>
           (?:
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1080,7 +1080,6 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1112,7 +1111,7 @@ repository:
         patterns: [
           {
             name: "entity.name.variable.event.cs"
-            match: "[_[:alpha:]][_[:alnum:]]*"
+            match: "@?[_[:alpha:]][_[:alnum:]]*"
           }
           {
             include: "#punctuation-comma"
@@ -1208,9 +1207,9 @@ repository:
       (?<returntype>
         (?<typename>
           (?:
-            (?:ref\\s+)?   # ref return
+            (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1218,7 +1217,6 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1272,11 +1270,11 @@ repository:
       }
     ]
   "constructor-declaration":
-    begin: "(?=[_[:alpha:]][_[:alnum:]]*\\s*\\()"
+    begin: "(?=@?[_[:alpha:]][_[:alnum:]]*\\s*\\()"
     end: "(?<=\\})|(?=;)"
     patterns: [
       {
-        match: "\\b([_[:alpha:]][_[:alnum:]]*)\\b"
+        match: "(@?[_[:alpha:]][_[:alnum:]]*)\\b"
         captures:
           "1":
             name: "entity.name.function.cs"
@@ -1323,7 +1321,7 @@ repository:
       }
     ]
   "destructor-declaration":
-    begin: "(~)([_[:alpha:]][_[:alnum:]]*)\\s*(?=\\()"
+    begin: "(~)(@?[_[:alpha:]][_[:alnum:]]*)\\s*(?=\\()"
     beginCaptures:
       "1":
         name: "punctuation.tilde.cs"
@@ -1349,9 +1347,9 @@ repository:
       (?x)
       (?<typename>
         (?:
-          (?:ref\\s+)?   # ref return
+          (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1359,7 +1357,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -1401,9 +1398,9 @@ repository:
       (?<operatorkeyword>(?:\\b(?:operator)))\\s*
       (?<typename>
         (?:
-          (?:ref\\s+)?   # ref return
+          (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1411,7 +1408,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -1526,7 +1522,7 @@ repository:
       }
       {
         name: "entity.name.label.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
     ]
   "return-statement":
@@ -1802,7 +1798,7 @@ repository:
                 (?<typename>
                   (?:
                     (?:
-                      (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+                      (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
                       (?<nameandtypeargs> # identifier + type arguments (if any)
                         \\g<identifier>\\s*
                         (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1810,7 +1806,6 @@ repository:
                       (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
                       (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                     )
-                    (?:\\s*\\*\\s*)* # pointer suffix?
                     (?:\\s*\\?\\s*)? # nullable suffix?
                     (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
                   )
@@ -1829,7 +1824,7 @@ repository:
                   }
                 ]
               "7":
-                name: "variable.other.cs"
+                name: "entity.name.variable.local.cs"
               "8":
                 name: "keyword.control.loop.in.cs"
           }
@@ -1924,7 +1919,7 @@ repository:
               (?<typename>
                 (?:
                   (?:
-                    (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+                    (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
                     (?<nameandtypeargs> # identifier + type arguments (if any)
                       \\g<identifier>\\s*
                       (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -1932,12 +1927,11 @@ repository:
                     (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
                     (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                   )
-                  (?:\\s*\\*\\s*)* # pointer suffix?
                   (?:\\s*\\?\\s*)? # nullable suffix?
                   (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
                 )
               )\\s*
-              (?:\\b(\\g<identifier>)\\b)?
+              (?:(\\g<identifier>)\\b)?
             '''
             captures:
               "1":
@@ -1947,7 +1941,7 @@ repository:
                   }
                 ]
               "6":
-                name: "variable.other.cs"
+                name: "entity.name.variable.local.cs"
           }
         ]
       }
@@ -2052,7 +2046,7 @@ repository:
       }
     ]
   "labeled-statement":
-    match: "([_[:alpha:]][_[:alnum:]]*)\\s*(:)"
+    match: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     captures:
       "1":
         name: "entity.name.label.cs"
@@ -2074,12 +2068,12 @@ repository:
     begin: '''
       (?x)
       (?:
-        (?:(\\bref)\\s+)?(\\bvar\\b)| # ref local
+        (?:(\\bref)\\s+(?:(\\breadonly)\\s+)?)?(\\bvar\\b)| # ref local
         (?<typename>
           (?:
-            (?:ref\\s+)?   # ref local
+            (?:ref\\s+(?:readonly\\s+)?)?   # ref local
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2087,7 +2081,6 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -2100,20 +2093,22 @@ repository:
       "1":
         name: "storage.modifier.cs"
       "2":
-        name: "keyword.other.var.cs"
+        name: "storage.modifier.cs"
       "3":
+        name: "keyword.other.var.cs"
+      "4":
         patterns: [
           {
             include: "#type"
           }
         ]
-      "8":
-        name: "variable.other.cs"
+      "9":
+        name: "entity.name.variable.local.cs"
     end: "(?=;|\\))"
     patterns: [
       {
-        name: "variable.other.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        name: "entity.name.variable.local.cs"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
         include: "#punctuation-comma"
@@ -2132,7 +2127,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2140,7 +2135,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2158,12 +2152,12 @@ repository:
           }
         ]
       "7":
-        name: "variable.other.cs"
+        name: "entity.name.variable.local.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "variable.other.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        name: "entity.name.variable.local.cs"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
         include: "#punctuation-comma"
@@ -2238,7 +2232,7 @@ repository:
       {
         match: '''
           (?x) # e.g. x
-          \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+          (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
           (?=[,)])
         '''
         captures:
@@ -2271,7 +2265,7 @@ repository:
       {
         match: '''
           (?x) # e.g. x
-          \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+          (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
           (?=[,)])
         '''
         captures:
@@ -2287,7 +2281,7 @@ repository:
         (?<typename>
           (?:
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2295,13 +2289,12 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
         )
       )\\s+
-      \\b(\\g<identifier>)\\b\\s*
+      (\\g<identifier>)\\b\\s*
       (?=[,)\\]])
     '''
     captures:
@@ -2314,7 +2307,7 @@ repository:
           }
         ]
       "7":
-        name: "variable.other.cs"
+        name: "entity.name.variable.local.cs"
   "declaration-expression-tuple":
     match: '''
       (?x) # e.g. int x OR var x
@@ -2323,7 +2316,7 @@ repository:
         (?<typename>
           (?:
             (?:
-              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<nameandtypeargs> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2331,13 +2324,12 @@ repository:
               (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
         )
       )\\s+
-      \\b(\\g<identifier>)\\b\\s*
+      (\\g<identifier>)\\b\\s*
       (?=[,)])
     '''
     captures:
@@ -2606,7 +2598,7 @@ repository:
   "tuple-literal-element":
     begin: '''
       (?x)
-      (?:([_[:alpha:]][_[:alnum:]]*)\\s*(:)\\s*)?
+      (?:(@?[_[:alpha:]][_[:alnum:]]*)\\s*(:)\\s*)?
       (?![,)])
     '''
     beginCaptures:
@@ -2721,7 +2713,7 @@ repository:
     ]
   identifier:
     name: "variable.other.readwrite.cs"
-    match: "[_[:alpha:]][_[:alnum:]]*"
+    match: "@?[_[:alpha:]][_[:alnum:]]*"
   "cast-expression":
     match: '''
       (?x)
@@ -2729,7 +2721,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2737,12 +2729,11 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )\\s*
-      (\\))(?=\\s*[_[:alnum:]\\(])
+      (\\))(?=\\s*@?[_[:alnum:]\\(])
     '''
     captures:
       "1":
@@ -2762,7 +2753,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2770,7 +2761,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2792,7 +2782,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2800,7 +2790,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2827,7 +2816,7 @@ repository:
       (?x)
       (?:(\\?)\\s*)?                                     # preceding null-conditional operator?
       (?:(\\.)\\s*)?                                     # preceding dot?
-      ([_[:alpha:]][_[:alnum:]]*)\\s*                   # method name
+      (@?[_[:alpha:]][_[:alnum:]]*)\\s*                   # method name
       (?<typeargs>\\s*<([^<>]|\\g<typeargs>)+>\\s*)?\\s* # type arguments
       (?=\\()                                           # open paren of argument list
     '''
@@ -2855,7 +2844,7 @@ repository:
       (?x)
       (?:(\\?)\\s*)?                        # preceding null-conditional operator?
       (?:(\\.)\\s*)?                        # preceding dot?
-      (?:([_[:alpha:]][_[:alnum:]]*)\\s*)? # property name
+      (?:(@?[_[:alpha:]][_[:alnum:]]*)\\s*)? # property name
       (?:(\\?)\\s*)?                        # null-conditional operator?
       (?=\\[)                              # open bracket of argument list
     '''
@@ -2881,7 +2870,7 @@ repository:
           (?x)
           (?:(\\?)\\s*)?                   # preceding null-conditional operator?
           (\\.)\\s*                        # preceding dot
-          ([_[:alpha:]][_[:alnum:]]*)\\s* # property name
+          (@?[_[:alpha:]][_[:alnum:]]*)\\s* # property name
           (?![_[:alnum:]]|\\(|(\\?)?\\[|<)  # next character is not alpha-numeric, nor a (, [, or <. Also, test for ?[
         '''
         captures:
@@ -2896,11 +2885,11 @@ repository:
         match: '''
           (?x)
           (\\.)?\\s*
-          ([_[:alpha:]][_[:alnum:]]*)
+          (@?[_[:alpha:]][_[:alnum:]]*)
           (?<typeparams>\\s*<([^<>]|\\g<typeparams>)+>\\s*)
           (?=
             (\\s*\\?)?
-            \\s*\\.\\s*[_[:alpha:]][_[:alnum:]]*
+            \\s*\\.\\s*@?[_[:alpha:]][_[:alnum:]]*
           )
         '''
         captures:
@@ -2918,10 +2907,10 @@ repository:
       {
         match: '''
           (?x)
-          ([_[:alpha:]][_[:alnum:]]*)
+          (@?[_[:alpha:]][_[:alnum:]]*)
           (?=
             (\\s*\\?)?
-            \\s*\\.\\s*[_[:alpha:]][_[:alnum:]]*
+            \\s*\\.\\s*@?[_[:alpha:]][_[:alnum:]]*
           )
         '''
         captures:
@@ -2945,7 +2934,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2953,7 +2942,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2982,7 +2970,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -2990,7 +2978,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3009,11 +2996,11 @@ repository:
   "array-creation-expression":
     begin: '''
       (?x)
-      \\b(new)\\b\\s*
+      \\b(new|stackalloc)\\b\\s*
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3021,7 +3008,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3115,12 +3101,12 @@ repository:
   parameter:
     match: '''
       (?x)
-      (?:(?:\\b(ref|params|out|this)\\b)\\s+)?
+      (?:(?:\\b(ref|params|out|in|this)\\b)\\s+)?
       (?<typename>
         (?:
           (?:ref\\s+)?   # ref return
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3128,7 +3114,6 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3145,7 +3130,7 @@ repository:
           }
         ]
       "7":
-        name: "variable.parameter.function.cs"
+        name: "entity.name.variable.parameter.cs"
   "argument-list":
     begin: "\\("
     beginCaptures:
@@ -3187,10 +3172,10 @@ repository:
       }
     ]
   "named-argument":
-    begin: "([_[:alpha:]][_[:alnum:]]*)\\s*(:)"
+    begin: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     beginCaptures:
       "1":
-        name: "variable.parameter.function.cs"
+        name: "entity.name.variable.parameter.cs"
       "2":
         name: "punctuation.separator.colon.cs"
     end: "(?=(,|\\)|\\]))"
@@ -3203,7 +3188,7 @@ repository:
     patterns: [
       {
         name: "storage.modifier.cs"
-        match: "\\b(ref|out)\\b"
+        match: "\\b(ref|out|in)\\b"
       }
       {
         include: "#declaration-expression-local"
@@ -3219,7 +3204,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3227,12 +3212,11 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )?
-      \\b(\\g<identifier>)\\b\\s*
+      \\s+(\\g<identifier>)\\b\\s*
       \\b(in)\\b\\s*
     '''
     beginCaptures:
@@ -3282,7 +3266,7 @@ repository:
     begin: '''
       (?x)
       \\b(let)\\b\\s*
-      \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+      (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
       (=)\\s*
     '''
     beginCaptures:
@@ -3325,7 +3309,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3333,12 +3317,11 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )?
-      \\b(\\g<identifier>)\\b\\s*
+      \\s+(\\g<identifier>)\\b\\s*
       \\b(in)\\b\\s*
     '''
     beginCaptures:
@@ -3386,7 +3369,7 @@ repository:
     match: '''
       (?x)
       \\b(into)\\b\\s*
-      \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+      (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
     '''
     captures:
       "1":
@@ -3463,7 +3446,7 @@ repository:
     match: '''
       (?x)
       \\b(into)\\b\\s*
-      \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+      (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
     '''
     captures:
       "1":
@@ -3476,14 +3459,14 @@ repository:
         begin: '''
           (?x)
           (?:\\b(async)\\b\\s*)?
-          \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+          (@?[_[:alpha:]][_[:alnum:]]*)\\b\\s*
           (=>)
         '''
         beginCaptures:
           "1":
             name: "storage.modifier.cs"
           "2":
-            name: "variable.parameter.function.cs"
+            name: "entity.name.variable.parameter.cs"
           "3":
             name: "keyword.operator.arrow.cs"
         end: "(?=\\)|;|}|,)"
@@ -3581,11 +3564,11 @@ repository:
   "lambda-parameter":
     match: '''
       (?x)
-      (ref|out)?\\s*
-      (?<typename>
+      (?:\\b(ref|out|in)\\b)?\\s*
+      (?:(?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3593,12 +3576,11 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
-      )?
-      \\b(\\g<identifier>)\\b\\s*
+      )\\s+)?
+      (\\g<identifier>)\\b\\s*
       (?=[,)])
     '''
     captures:
@@ -3611,7 +3593,7 @@ repository:
           }
         ]
       "7":
-        name: "variable.parameter.function.cs"
+        name: "entity.name.variable.parameter.cs"
   type:
     name: "meta.type.cs"
     patterns: [
@@ -3620,6 +3602,9 @@ repository:
       }
       {
         include: "#ref-modifier"
+      }
+      {
+        include: "#readonly-modifier"
       }
       {
         include: "#tuple-type"
@@ -3643,6 +3628,9 @@ repository:
   "ref-modifier":
     name: "storage.modifier.cs"
     match: "\\b(ref)\\b"
+  "readonly-modifier":
+    name: "storage.modifier.cs"
+    match: "\\b(readonly)\\b"
   "tuple-type":
     begin: "\\("
     beginCaptures:
@@ -3666,7 +3654,7 @@ repository:
       (?<typename>
         (?:
           (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
             (?<nameandtypeargs> # identifier + type arguments (if any)
               \\g<identifier>\\s*
               (?<typeargs>\\s*<(?:[^<>]|\\g<typeargs>)+>\\s*)?
@@ -3674,12 +3662,11 @@ repository:
             (?:\\s*\\.\\s*\\g<nameandtypeargs>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )
-      (?:\\b(?<tuplename>\\g<identifier>)\\b)?
+      (?:(?<tuplename>\\g<identifier>)\\b)?
     '''
     captures:
       "1":
@@ -3698,7 +3685,7 @@ repository:
   "type-name":
     patterns: [
       {
-        match: "([_[:alpha:]][_[:alnum:]]*)\\s*(\\:\\:)"
+        match: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(\\:\\:)"
         captures:
           "1":
             name: "entity.name.type.alias.cs"
@@ -3706,7 +3693,7 @@ repository:
             name: "punctuation.separator.coloncolon.cs"
       }
       {
-        match: "([_[:alpha:]][_[:alnum:]]*)\\s*(\\.)"
+        match: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(\\.)"
         captures:
           "1":
             name: "storage.type.cs"
@@ -3714,7 +3701,7 @@ repository:
             name: "punctuation.accessor.cs"
       }
       {
-        match: "(\\.)\\s*([_[:alpha:]][_[:alnum:]]*)"
+        match: "(\\.)\\s*(@?[_[:alpha:]][_[:alnum:]]*)"
         captures:
           "1":
             name: "punctuation.accessor.cs"
@@ -3723,7 +3710,7 @@ repository:
       }
       {
         name: "entity.name.type.cs"
-        match: "[_[:alpha:]][_[:alnum:]]*"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
     ]
   "type-arguments":

--- a/grammars/csharp.cson
+++ b/grammars/csharp.cson
@@ -1824,7 +1824,7 @@ repository:
                   }
                 ]
               "7":
-                name: "entity.name.variable.local.cs"
+                name: "variable.other.cs"
               "8":
                 name: "keyword.control.loop.in.cs"
           }
@@ -1941,7 +1941,7 @@ repository:
                   }
                 ]
               "6":
-                name: "entity.name.variable.local.cs"
+                name: "variable.other.cs"
           }
         ]
       }
@@ -2103,11 +2103,11 @@ repository:
           }
         ]
       "9":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
     end: "(?=;|\\))"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
         match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2152,11 +2152,11 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
     end: "(?=;)"
     patterns: [
       {
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
         match: "@?[_[:alpha:]][_[:alnum:]]*"
       }
       {
@@ -2307,7 +2307,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.local.cs"
+        name: "variable.other.cs"
   "declaration-expression-tuple":
     match: '''
       (?x) # e.g. int x OR var x
@@ -3130,7 +3130,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
   "argument-list":
     begin: "\\("
     beginCaptures:
@@ -3175,7 +3175,7 @@ repository:
     begin: "(@?[_[:alpha:]][_[:alnum:]]*)\\s*(:)"
     beginCaptures:
       "1":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
       "2":
         name: "punctuation.separator.colon.cs"
     end: "(?=(,|\\)|\\]))"
@@ -3466,7 +3466,7 @@ repository:
           "1":
             name: "storage.modifier.cs"
           "2":
-            name: "entity.name.variable.parameter.cs"
+            name: "variable.parameter.function.cs"
           "3":
             name: "keyword.operator.arrow.cs"
         end: "(?=\\)|;|}|,)"
@@ -3593,7 +3593,7 @@ repository:
           }
         ]
       "7":
-        name: "entity.name.variable.parameter.cs"
+        name: "variable.parameter.function.cs"
   type:
     name: "meta.type.cs"
     patterns: [

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -14,6 +14,6 @@ def convert(string):
   result = re.sub(r'\?<([a-zA-Z-_]*)>', lambda x: x.group().replace('-', ''), string)
   return re.sub(r'\\\\g<([a-zA-Z-]*)>', lambda x: x.group().replace('-', ''), result)
 
-content = read('csharp.cson')
+content = read('../grammars/csharp.cson')
 updated = convert(content)
-write('csharp-new.cson', updated)
+write('../grammars/csharp.cson', updated)


### PR DESCRIPTION
### Description of the Change

As you know, *language-csharp* grammar that is used by both Atom and Github comes <a href="https://github.com/dotnet/csharp-tmLanguage">from upstream</a>. So this PR updates the grammar as there were a lot of fixes and improvements since the grammar was updated last time (https://github.com/dotnet/csharp-tmLanguage/pull/114 https://github.com/dotnet/csharp-tmLanguage/pull/132 https://github.com/dotnet/csharp-tmLanguage/pull/113 etc.)

Python script from `scripts/` folder was used to keep PCRE support, it removed dashes from group names. Manual fixes were applied according to these commits: https://github.com/atom/language-csharp/commit/3b9397005da78e2f233e534b8e23bb50ced17f6f https://github.com/atom/language-csharp/commit/15df1701985ce9cfcbd144d515bef377d0cb863e https://github.com/atom/language-csharp/commit/17f89b8e68cf2b44a9141512cea240689ad51190 (GitHub highlighter needs them)

### Before

```csharp
Span<int> arr = stackalloc [] {1, 2, 3};
static void M(in S arg);
public ref struct RefStruct { }
```

### After

C# language syntax highlighting is improved and now supports `ref struct`, `stackalloc`, etc. 

![image](https://user-images.githubusercontent.com/6759207/44750738-e0948b00-ab1e-11e8-93f3-9399c2e9a825.png)


### Possible Drawbacks

None.